### PR TITLE
Credit card: Add PaymentMethodNonce

### DIFF
--- a/credit_card.go
+++ b/credit_card.go
@@ -3,6 +3,7 @@ package braintree
 type CreditCard struct {
 	CustomerId                string             `xml:"customer-id,omitempty"`
 	Token                     string             `xml:"token,omitempty"`
+	PaymentMethodNonce        string             `xml:"payment-method-nonce,omitempty"`
 	Number                    string             `xml:"number,omitempty"`
 	ExpirationDate            string             `xml:"expiration-date,omitempty"`
 	ExpirationMonth           string             `xml:"expiration-month,omitempty"`


### PR DESCRIPTION
This is needed for when card tokenization is done by the braintree
client SDK.

See:
https://developers.braintreepayments.com/javascript+ruby/sdk/client/credit-cards