### PR TITLE
Use fixed precision data type for amounts

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -1,0 +1,60 @@
+package braintree
+
+import (
+	"bytes"
+	"strconv"
+	"strings"
+)
+
+const precision = 16
+
+// Decimal represents fixed precision numbers
+type Decimal struct {
+	Unscaled int64
+	Scale    int
+}
+
+// NewDecimal creates a new decimal number equal to
+// unscaled ** 10 ^ (-scale)
+func NewDecimal(unscaled int64, scale int) *Decimal {
+	return &Decimal{Unscaled: unscaled, Scale: scale}
+}
+
+// MarshalText outputs a decimal representation of the scaled number
+func (d *Decimal) MarshalText() (text []byte, err error) {
+	b := new(bytes.Buffer)
+	if d.Scale <= 0 {
+		b.WriteString(strconv.FormatInt(d.Unscaled, 10))
+		b.WriteString(strings.Repeat("0", -d.Scale))
+	} else {
+		str := strconv.FormatInt(d.Unscaled, 10)
+		b.WriteString(str[:len(str)-d.Scale])
+		b.WriteString(".")
+		b.WriteString(str[len(str)-d.Scale:])
+	}
+	return b.Bytes(), nil
+}
+
+// UnmarshalText creates a Decimal from a string representation (e.g. 5.20)
+// Currently only supports decimal strings
+func (d *Decimal) UnmarshalText(text []byte) (err error) {
+	var (
+		str            = string(text)
+		unscaled int64 = 0
+		scale    int   = 0
+	)
+
+	if i := strings.Index(str, "."); i != -1 {
+		scale = len(str) - i - 1
+		str = strings.Replace(str, ".", "", 1)
+	}
+
+	if unscaled, err = strconv.ParseInt(str, 10, 64); err != nil {
+		return err
+	}
+
+	d.Unscaled = unscaled
+	d.Scale = scale
+
+	return nil
+}

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -1,0 +1,65 @@
+package braintree
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDecimalUnmarshalText(t *testing.T) {
+	tests := []struct {
+		in          []byte
+		out         *Decimal
+		shouldError bool
+	}{
+		{[]byte("2.50"), NewDecimal(250, 2), false},
+		{[]byte("2"), NewDecimal(2, 0), false},
+		{[]byte("-5.504"), NewDecimal(-5504, 3), false},
+		{[]byte("0.5"), NewDecimal(5, 1), false},
+		{[]byte(".5"), NewDecimal(5, 1), false},
+		{[]byte("5.504.98"), NewDecimal(0, 0), true},
+		{[]byte("5E6"), NewDecimal(0, 0), true},
+	}
+
+	for _, tt := range tests {
+		d := &Decimal{}
+		err := d.UnmarshalText(tt.in)
+
+		if tt.shouldError {
+			if err == nil {
+				t.Errorf("expected UnmarshalText(%s) => to error, but it did not", tt.in)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("expected UnmarshalText(%s) => to not error, but it did with %s", tt.in, err)
+			}
+		}
+
+		if !reflect.DeepEqual(d, tt.out) {
+			t.Errorf("UnmarshalText(%s) => %+v, want %+v", tt.in, d, tt.out)
+		}
+	}
+}
+
+func TestDecimalMarshalText(t *testing.T) {
+	tests := []struct {
+		in  *Decimal
+		out []byte
+	}{
+		{NewDecimal(250, -2), []byte("25000")},
+		{NewDecimal(2, 0), []byte("2")},
+		{NewDecimal(250, 2), []byte("2.50")},
+		{NewDecimal(4586, 2), []byte("45.86")},
+		{NewDecimal(-5504, 2), []byte("-55.04")},
+	}
+
+	for _, tt := range tests {
+		b, err := tt.in.MarshalText()
+		if err != nil {
+			t.Errorf("expected %+v.MarshaText() => to not error, but it did with %s", tt.in, err)
+		}
+
+		if string(tt.out) != string(b) {
+			t.Errorf("%+v.MarshaText() => %s, want %s", tt.in, b, tt.out)
+		}
+	}
+}

--- a/examples/server.go
+++ b/examples/server.go
@@ -17,10 +17,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/lionelbarrow/braintree-go"
 	"html/template"
 	"net/http"
 	"os"
+
+	"github.com/lionelbarrow/braintree-go"
 )
 
 type BraintreeJS struct {
@@ -43,7 +44,7 @@ func createTransaction(w http.ResponseWriter, r *http.Request) {
 
 	tx := &braintree.Transaction{
 		Type:   "sale",
-		Amount: 100,
+		Amount: braintree.NewDecimal(10000, 2),
 		CreditCard: &braintree.CreditCard{
 			Number:          r.FormValue("number"),
 			CVV:             r.FormValue("cvv"),

--- a/merchant_account_integration_test.go
+++ b/merchant_account_integration_test.go
@@ -73,12 +73,12 @@ func TestMerchantAccountTransaction(t *testing.T) {
 
 	tx, err := testGateway.Transaction().Create(&Transaction{
 		Type:   "sale",
-		Amount: 100.00 + offset(),
+		Amount: randomAmount(),
 		CreditCard: &CreditCard{
 			Number:         testCreditCards["visa"].Number,
 			ExpirationDate: "05/14",
 		},
-		ServiceFeeAmount:  5.00,
+		ServiceFeeAmount:  NewDecimal(500, 2),
 		MerchantAccountId: strconv.Itoa(acctId),
 	})
 

--- a/transaction.go
+++ b/transaction.go
@@ -6,7 +6,7 @@ type Transaction struct {
 	CustomerID          string               `xml:"customer-id,omitempty"`
 	Status              string               `xml:"status,omitempty"`
 	Type                string               `xml:"type,omitempty"`
-	Amount              float64              `xml:"amount"`
+	Amount              *Decimal             `xml:"amount"`
 	OrderId             string               `xml:"order-id,omitempty"`
 	PaymentMethodToken  string               `xml:"payment-method-token,omitempty"`
 	MerchantAccountId   string               `xml:"merchant-account-id,omitempty"`
@@ -16,7 +16,7 @@ type Transaction struct {
 	BillingAddress      *Address             `xml:"billing,omitempty"`
 	ShippingAddress     *Address             `xml:"shipping,omitempty"`
 	Options             *TransactionOptions  `xml:"options,omitempty"`
-	ServiceFeeAmount    float64              `xml:"service-fee-amount,attr,omitempty"`
+	ServiceFeeAmount    *Decimal             `xml:"service-fee-amount,attr,omitempty"`
 	CreatedAt           string               `xml:"created-at,omitempty"`
 	UpdatedAt           string               `xml:"updated-at,omitempty"`
 	DisbursementDetails *DisbursementDetails `xml:"disbursement-details,omitempty"`

--- a/transaction_gateway.go
+++ b/transaction_gateway.go
@@ -24,7 +24,7 @@ func (g *TransactionGateway) Create(tx *Transaction) (*Transaction, error) {
 
 // SubmitForSettlement submits the transaction with the specified id for settlement.
 // If the amount is omitted, the full amount is settled.
-func (g *TransactionGateway) SubmitForSettlement(id string, amount ...float64) (*Transaction, error) {
+func (g *TransactionGateway) SubmitForSettlement(id string, amount ...*Decimal) (*Transaction, error) {
 	var tx *Transaction
 	if len(amount) > 0 {
 		tx = &Transaction{


### PR DESCRIPTION
To avoid the loss of precision that might occur from using floats.