### PR TITLE
Adding support for CustomerId field on client token requests (to support vault workflow)

### DIFF
--- a/client_token.go
+++ b/client_token.go
@@ -1,6 +1,7 @@
 package braintree
 
 type ClientToken struct {
-	XMLName string `xml:"client-token"`
-	Version int    `xml:"version"`
+	XMLName    string `xml:"client-token"`
+	CustomerID string `xml:"customerId,omitempty"`
+	Version    int    `xml:"version"`
 }

--- a/client_token.go
+++ b/client_token.go
@@ -1,6 +1,6 @@
 package braintree
 
-type ClientToken struct {
+type ClientTokenRequest struct {
 	XMLName    string `xml:"client-token"`
 	CustomerID string `xml:"customerId,omitempty"`
 	Version    int    `xml:"version"`

--- a/client_token_gateway.go
+++ b/client_token_gateway.go
@@ -8,15 +8,15 @@ type ClientTokenGateway struct {
 	*Braintree
 }
 
-func NewClientTokenRequest() ClientToken {
-	return ClientToken{Version: clientTokenVersion}
+func NewClientTokenRequest() *ClientTokenRequest {
+	return &ClientTokenRequest{Version: clientTokenVersion}
 }
 
 func (g *ClientTokenGateway) Generate() (string, error) {
 	return g.GenerateWith(NewClientTokenRequest())
 }
 
-func (g *ClientTokenGateway) GenerateWith(tokenRequest ClientToken) (string, error) {
+func (g *ClientTokenGateway) GenerateWith(tokenRequest *ClientTokenRequest) (string, error) {
 	tokenRequest.Version = clientTokenVersion
 	resp, err := g.execute("POST", "client_token", tokenRequest)
 	if err != nil {

--- a/client_token_gateway.go
+++ b/client_token_gateway.go
@@ -8,8 +8,17 @@ type ClientTokenGateway struct {
 	*Braintree
 }
 
+func NewClientTokenRequest() ClientToken {
+	return ClientToken{Version: clientTokenVersion}
+}
+
 func (g *ClientTokenGateway) Generate() (string, error) {
-	resp, err := g.execute("POST", "client_token", ClientToken{Version: clientTokenVersion})
+	return g.GenerateWith(NewClientTokenRequest())
+}
+
+func (g *ClientTokenGateway) GenerateWith(tokenRequest ClientToken) (string, error) {
+	tokenRequest.Version = clientTokenVersion
+	resp, err := g.execute("POST", "client_token", tokenRequest)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Simple change that adds CustomerID field to the ClientToken struct
Also renamed ClientToken struct to ClientTokenRequest as that more accurately describes it.

