### PR TITLE
Marshal scaled zero decimal correctly

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -28,6 +28,9 @@ func (d *Decimal) MarshalText() (text []byte, err error) {
 		b.WriteString(strings.Repeat("0", -d.Scale))
 	} else {
 		str := strconv.FormatInt(d.Unscaled, 10)
+		if len(str) < d.Scale {
+			str = str + strings.Repeat("0", d.Scale)
+		}
 		b.WriteString(str[:len(str)-d.Scale])
 		b.WriteString(".")
 		b.WriteString(str[len(str)-d.Scale:])

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -13,6 +13,7 @@ func TestDecimalUnmarshalText(t *testing.T) {
 	}{
 		{[]byte("2.50"), NewDecimal(250, 2), false},
 		{[]byte("2"), NewDecimal(2, 0), false},
+		{[]byte("0.00"), NewDecimal(0, 2), false},
 		{[]byte("-5.504"), NewDecimal(-5504, 3), false},
 		{[]byte("0.5"), NewDecimal(5, 1), false},
 		{[]byte(".5"), NewDecimal(5, 1), false},
@@ -47,6 +48,7 @@ func TestDecimalMarshalText(t *testing.T) {
 	}{
 		{NewDecimal(250, -2), []byte("25000")},
 		{NewDecimal(2, 0), []byte("2")},
+		{NewDecimal(0, 2), []byte("0.00")},
 		{NewDecimal(250, 2), []byte("2.50")},
 		{NewDecimal(4586, 2), []byte("45.86")},
 		{NewDecimal(-5504, 2), []byte("-55.04")},


### PR DESCRIPTION
Calling MarshalText on `NewDecimal(0, 2)` would panic because of an
out-of-bounds slice access.  The expected result of marshaling this
decimal is "0.00".

This commit checks the length of the string representing the unscaled
number and pads it with zero if the string is shorter than the scale.