### PR TITLE
Fix tests that depend on math/rand for uniqueness. 

### DIFF
--- a/merchant_account_integration_test.go
+++ b/merchant_account_integration_test.go
@@ -2,21 +2,19 @@ package braintree
 
 import (
 	"encoding/xml"
-	"math/rand"
-	"strconv"
 	"testing"
-	"time"
+
+	"github.com/lionelbarrow/braintree-go/testhelpers"
 )
 
-var acctId int
+var acctId string
 
 func TestMerchantAccountCreate(t *testing.T) {
-	rand.Seed(time.Now().UTC().UnixNano())
-	acctId = rand.Int() + 1
+	acctId = testhelpers.RandomString()
 	acct := MerchantAccount{
 		MasterMerchantAccountId: testMerchantAccountId,
 		TOSAccepted:             true,
-		Id:                      strconv.Itoa(acctId),
+		Id:                      acctId,
 		Individual: &MerchantAccountPerson{
 			FirstName:   "Kayle",
 			LastName:    "Gishen",
@@ -67,7 +65,7 @@ func TestMerchantAccountCreate(t *testing.T) {
 }
 
 func TestMerchantAccountTransaction(t *testing.T) {
-	if acctId == 0 {
+	if acctId == "" {
 		TestMerchantAccountCreate(t)
 	}
 
@@ -81,7 +79,7 @@ func TestMerchantAccountTransaction(t *testing.T) {
 			ExpirationDate: "05/14",
 		},
 		ServiceFeeAmount:  NewDecimal(500, 2),
-		MerchantAccountId: strconv.Itoa(acctId),
+		MerchantAccountId: acctId,
 	})
 
 	t.Log(tx)

--- a/testhelpers/random.go
+++ b/testhelpers/random.go
@@ -1,0 +1,21 @@
+package testhelpers
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/binary"
+	"strconv"
+)
+
+func RandomInt() int64 {
+	var n int64
+	b := make([]byte, 8)
+	rand.Read(b)
+	buf := bytes.NewBuffer(b)
+	binary.Read(buf, binary.LittleEndian, &n)
+	return n
+}
+
+func RandomString() string {
+	return strconv.FormatInt(RandomInt(), 10)
+}

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -2,9 +2,9 @@ package braintree
 
 import (
 	"math/rand"
-	"strconv"
 	"testing"
-	"time"
+
+	"github.com/lionelbarrow/braintree-go/testhelpers"
 )
 
 func randomAmount() *Decimal {
@@ -79,20 +79,21 @@ func TestTransactionSearch(t *testing.T) {
 		return err
 	}
 
-	ts := strconv.FormatInt(time.Now().Unix(), 10)
-	name := "Erik-" + ts
+	unique := testhelpers.RandomString()
 
-	if err := createTx(randomAmount(), name); err != nil {
+	name0 := "Erik-" + unique
+	if err := createTx(randomAmount(), name0); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := createTx(randomAmount(), "Lionel-"+ts); err != nil {
+	name1 := "Lionel-" + unique
+	if err := createTx(randomAmount(), name1); err != nil {
 		t.Fatal(err)
 	}
 
 	query := new(SearchQuery)
 	f := query.AddTextField("customer-first-name")
-	f.Is = name
+	f.Is = name0
 
 	result, err := txg.Search(query)
 	if err != nil {
@@ -104,8 +105,8 @@ func TestTransactionSearch(t *testing.T) {
 	}
 
 	tx := result.Transactions[0]
-	if x := tx.Customer.FirstName; x != name {
-		t.Log(name)
+	if x := tx.Customer.FirstName; x != name0 {
+		t.Log(name0)
 		t.Fatal(x)
 	}
 }


### PR DESCRIPTION
What
===
Fix tests that depend on math/rand for uniqueness by replacing the unix timestamp based random number generation with crypto random.

Why
===
The tests were using math/rand to make the test data that is created in the sandbox environment unique to that test run. Tests were failing often on TravisCI because the tests are run on multiple versions of Go at the same time. At roughtly the same time the test was running, and creating transactions that had the same customer name because the tests start at the same time resulting in the unix timestamp being the same. Using crypto/rand significantly decreases the possibility of collision.