### PR TITLE
Fix doc formatting

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,13 @@
+/*
+Package braintree is a client library for Braintree.
+
+API errors are intended to be consumed in two ways. One, they can be dealt with as a single unit:
+
+    result, err := gateway.Create(transaction)
+    err.Error() => "A top level error message"
+
+Second, you can drill down to see specific error messages on a field-by-field basis:
+
+    err.For("Transaction").On("Base")[0].Message => "A more specific error message"
+*/
+package braintree

--- a/errors.go
+++ b/errors.go
@@ -1,12 +1,3 @@
-/* API errors are intended to be consumed in two ways. One, they can be dealt with as a single unit:
-
-result, err := gateway.Create(transaction)
-err.Error() => "A top level error message"
-
-Second, you can drill down to see specific error messages on a field-by-field basis:
-
-err.For("Transaction").On("Base")[0].Message => "A more specific error message"
-*/
 package braintree
 
 import "strings"


### PR DESCRIPTION
This PR does a few things:

1) Fixes the package synposis as viewable from the search results on [godoc](https://godoc.org/?q=braintree-go).
2) Indents program snippets as recommended by [effective go](https://golang.org/doc/effective_go.html#commentary).
3) Breaks out the documentation into its own `doc.go` file for clarity, since packages should only have one package-level comment.
