### PR TITLE
Add an explicit go_import_path.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ env:
     BRAINTREE_PRIV_KEY=66062a3876e2dc298f2195f0bf173f5a
     BRAINTREE_CSE_KEY=MIIBCgKCAQEAvs9I/M9J2q82+v2xedowoF4MOExF4zkQRZ7DIPg9Fh7Y9N3Cx0Xq+vxPrUvgJpGz0zbmlHzQFxfhvKmm1tE1nh1KFdk1ALmBVmWgYDVIH+16hk6KW2TQQncqV96DZbfiZroHAPNKeRlF7lqQrGFTSE0gsedJnsvgPUBsFFayLs5JPlzU5O9jUGVctNf1f6pwK8G0LaqKTvXme5p0Hc4AZWguX/AN6fQQYCRVeRG0iQaJFAtTmtB1dFG7rabSCTeI2Zv4SXyVPAkEOqqjG6AS3Mpn/o1qQZx9deD7jzFegNX+L8Z7G65haPBm/BRoVjfZL7MiK1eOQI+/0Nw56tOdXwIDAQAB
 
+go_import_path: github.com/lionelbarrow/braintree-go
+
 test:
   - go vet ./...
   - go test -v ./...


### PR DESCRIPTION
What
===
Add an explicit go_import_path pointing to the main repository.

Why
===
When TravisCI runs tests in forks of this package it needs to setup the
environment with the package downloaded to the src path that matches the
main import path, otherwise the absolute imports within the package will
be referencing the non-forked version and be downloaded.

Examples
===
Before
---
![screen shot 2016-05-13 at 1 20 29 pm](https://cloud.githubusercontent.com/assets/351529/15260841/f57cb7ae-190d-11e6-8e27-4d5f51fa96ea.png)

After
---
![screen shot 2016-05-13 at 1 22 01 pm](https://cloud.githubusercontent.com/assets/351529/15260839/f33b71ce-190d-11e6-847f-645ad05e8251.png)
