### PR TITLE
Fix test that could not be run in parallel.

### DIFF
--- a/customer_integration_test.go
+++ b/customer_integration_test.go
@@ -2,6 +2,8 @@ package braintree
 
 import (
 	"testing"
+
+	"github.com/lionelbarrow/braintree-go/testhelpers"
 )
 
 // This test will fail unless you set up your Braintree sandbox account correctly. See TESTING.md for details.
@@ -51,9 +53,11 @@ func TestCustomer(t *testing.T) {
 	}
 
 	// Update
+	unique := testhelpers.RandomString()
+	newFirstName := "John" + unique
 	c2, err := testGateway.Customer().Update(&Customer{
 		Id:        customer.Id,
-		FirstName: "John",
+		FirstName: newFirstName,
 	})
 
 	t.Log(c2)
@@ -61,7 +65,7 @@ func TestCustomer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if c2.FirstName != "John" {
+	if c2.FirstName != newFirstName {
 		t.Fatal("first name not changed")
 	}
 
@@ -80,7 +84,7 @@ func TestCustomer(t *testing.T) {
 	// Search
 	query := new(SearchQuery)
 	f := query.AddTextField("first-name")
-	f.Is = "John"
+	f.Is = newFirstName
 	searchResult, err := testGateway.Customer().Search(query)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
What
===
Change the Customer test to use a unique value when creating value on the sandbox account that the test then searches for.

Why
===
The test was updating a Customer to have a first name of "John" and searching for all customers with that name. If this test is run in parallel with itself on the same sandbox account it will get results from other runs of this test and fail because the Customer Ids do not match.