### PR TITLE
Fix parse signature and status code issue for submerchant update

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -9,7 +9,6 @@ Before running the integration tests with `go test`, make sure the following env
 ```
 export BRAINTREE_MERCH_ID={your-merchant-id}
 export BRAINTREE_MERCH_ACCT_ID={your-merchant-account-id}
-export BRAINTREE_SUB_MERCH_ACCT_ID={your-sub-merchant-account-id}
 export BRAINTREE_PUB_KEY={your-public-key}
 export BRAINTREE_PRIV_KEY={your-private-key}
 ```

--- a/TESTING.md
+++ b/TESTING.md
@@ -9,6 +9,7 @@ Before running the integration tests with `go test`, make sure the following env
 ```
 export BRAINTREE_MERCH_ID={your-merchant-id}
 export BRAINTREE_MERCH_ACCT_ID={your-merchant-account-id}
+export BRAINTREE_SUB_MERCH_ACCT_ID={your-sub-merchant-account-id}
 export BRAINTREE_PUB_KEY={your-public-key}
 export BRAINTREE_PRIV_KEY={your-private-key}
 ```
@@ -79,4 +80,4 @@ Number of cycles:       For the duration of the subscription.
 
 #### Testing disbursement details
 
-In Braintree's sandbox environment, transactions do not disburse immediately. The implementation of disbursement details is tested in `disbursement_integration_test.go` using an already-disbursed transaction on the sandbox account associated with the Travis CI build. This test does not pass in other environments, and serves as a proof-of-concept. To make all of the tests pass, you will either need to comment out this test, or replace the values inside of it with the values from a disbursed transaction on your account. 
+In Braintree's sandbox environment, transactions do not disburse immediately. The implementation of disbursement details is tested in `disbursement_integration_test.go` using an already-disbursed transaction on the sandbox account associated with the Travis CI build. This test does not pass in other environments, and serves as a proof-of-concept. To make all of the tests pass, you will either need to comment out this test, or replace the values inside of it with the values from a disbursed transaction on your account.

--- a/hmac.go
+++ b/hmac.go
@@ -40,19 +40,26 @@ func (h hmacer) verifySignature(signature, payload string) (bool, error) {
 	return hmac.Equal([]byte(expectedSignature), []byte(signature)), nil
 }
 
-func (h hmacer) parseSignature(signatureKeyPair string) (string, error) {
-	if !strings.Contains(signatureKeyPair, "|") {
+func (h hmacer) getMatchingSignature(signaturePairs string) (string, string) {
+	pairs := strings.Split(signaturePairs, "&")
+	for _, pair := range pairs {
+		split := strings.Split(pair, "|")
+		if len(split) == 2 && split[0] == h.Braintree.PublicKey {
+			return split[0], split[1]
+		}
+	}
+	return "", ""
+}
+
+func (h hmacer) parseSignature(signatureKeyPairs string) (string, error) {
+	if !strings.Contains(signatureKeyPairs, "|") {
 		return "", SignatureError{"Signature-key pair does not contain |"}
 	}
-	split := strings.Split(signatureKeyPair, "|")
-	if len(split) != 2 {
-		return "", SignatureError{"Signature-key pair contains more than one |"}
-	}
-	publicKey := split[0]
+	publicKey, signature := h.getMatchingSignature(signatureKeyPairs)
 	if publicKey != h.Braintree.PublicKey {
 		return "", SignatureError{"Signature-key pair contains the wrong public key!"}
 	}
-	return split[1], nil
+	return signature, nil
 }
 
 func (h hmacer) hmac(payload string) (string, error) {

--- a/merchant_account_gateway.go
+++ b/merchant_account_gateway.go
@@ -12,6 +12,8 @@ func (g *MerchantAccountGateway) Create(ma *MerchantAccount) (*MerchantAccount, 
 		return nil, err
 	}
 	switch resp.StatusCode {
+	case 200:
+		fallthrough
 	case 201:
 		return resp.merchantAccount()
 	}
@@ -39,6 +41,8 @@ func (g *MerchantAccountGateway) Update(ma *MerchantAccount) (*MerchantAccount, 
 		return nil, err
 	}
 	switch resp.StatusCode {
+	case 200:
+		fallthrough
 	case 201:
 		return resp.merchantAccount()
 	}

--- a/response.go
+++ b/response.go
@@ -132,7 +132,7 @@ type InvalidResponseError interface {
 }
 
 func (e *invalidResponseError) Error() string {
-	return fmt.Sprintf("braintree returned invalid response (%d)", e.resp.StatusCode)
+	return fmt.Sprintf("braintree returned invalid response - status(%d) body(%s)", e.resp.StatusCode, string(e.resp.Body))
 }
 
 func (e *invalidResponseError) Response() *Response {

--- a/subscription.go
+++ b/subscription.go
@@ -31,6 +31,7 @@ type Subscription struct {
 	NumberOfBillingCycles   *nullable.NullInt64  `xml:"number-of-billing-cycles,omitempty"`
 	PaidThroughDate         string               `xml:"paid-through-date,omitempty"`
 	PaymentMethodToken      string               `xml:"payment-method-token,omitempty"`
+	PaymentMethodNonce      string               `xml:"payment-method-nonce,omitempty"`
 	PlanId                  string               `xml:"plan-id,omitempty"`
 	Price                   *Decimal             `xml:"price,omitempty"`
 	Status                  string               `xml:"status,omitempty"`

--- a/test_values.go
+++ b/test_values.go
@@ -18,3 +18,4 @@ var testGateway = New(
 )
 
 var testMerchantAccountId = os.Getenv("BRAINTREE_MERCH_ACCT_ID")
+var testSubMerchantAccountId = os.Getenv("BRAINTREE_SUB_MERCH_ACCT_ID")

--- a/test_values.go
+++ b/test_values.go
@@ -18,4 +18,3 @@ var testGateway = New(
 )
 
 var testMerchantAccountId = os.Getenv("BRAINTREE_MERCH_ACCT_ID")
-var testSubMerchantAccountId = os.Getenv("BRAINTREE_SUB_MERCH_ACCT_ID")

--- a/transaction.go
+++ b/transaction.go
@@ -6,15 +6,17 @@ import (
 	"github.com/lionelbarrow/braintree-go/nullable"
 )
 
-type EscrowStatus string
-
-const (
-	HoldPending    EscrowStatus = "hold_pending"
-	Held           EscrowStatus = "held"
-	ReleasePending EscrowStatus = "release_pending"
-	Released       EscrowStatus = "released"
-	Refunded       EscrowStatus = "refunded"
-	Unrecognized   EscrowStatus = "unrecognized"
+var (
+	EscrowStatus = struct {
+		HoldPending, Held, ReleasePending, Released, Refunded, Unrecognized string
+	}{
+		HoldPending:    "hold_pending",
+		Held:           "held",
+		ReleasePending: "release_pending",
+		Released:       "released",
+		Refunded:       "refunded",
+		Unrecognized:   "unrecognized",
+	}
 )
 
 type Transaction struct {
@@ -45,7 +47,7 @@ type Transaction struct {
 	ProcessorResponseText      string               `xml:"processor-response-text,omitempty"`
 	ProcessorAuthorizationCode string               `xml:"processor-authorization-code,omitempty"`
 	SettlementBatchId          string               `xml:"settlement-batch-id,omitempty"`
-	EscrowStatus               EscrowStatus         `xml:"escrow-status,omitempty"`
+	EscrowStatus               string               `xml:"escrow-status,omitempty"`
 }
 
 // TODO: not all transaction fields are implemented yet, here are the missing fields (add on demand)

--- a/transaction.go
+++ b/transaction.go
@@ -1,8 +1,20 @@
 package braintree
 
 import (
-	"github.com/lionelbarrow/braintree-go/nullable"
 	"time"
+
+	"github.com/lionelbarrow/braintree-go/nullable"
+)
+
+type EscrowStatus string
+
+const (
+	HoldPending    EscrowStatus = "hold_pending"
+	Held           EscrowStatus = "held"
+	ReleasePending EscrowStatus = "release_pending"
+	Released       EscrowStatus = "released"
+	Refunded       EscrowStatus = "refunded"
+	Unrecognized   EscrowStatus = "unrecognized"
 )
 
 type Transaction struct {
@@ -33,6 +45,7 @@ type Transaction struct {
 	ProcessorResponseText      string               `xml:"processor-response-text,omitempty"`
 	ProcessorAuthorizationCode string               `xml:"processor-authorization-code,omitempty"`
 	SettlementBatchId          string               `xml:"settlement-batch-id,omitempty"`
+	EscrowStatus               EscrowStatus         `xml:"escrow-status,omitempty"`
 }
 
 // TODO: not all transaction fields are implemented yet, here are the missing fields (add on demand)
@@ -87,7 +100,6 @@ type Transaction struct {
 //   </descriptor>
 //   <recurring type="boolean">true</recurring>
 //   <channel nil="true"></channel>
-//   <escrow-status nil="true"></escrow-status>
 // </transaction>
 
 type Transactions struct {
@@ -99,6 +111,7 @@ type TransactionOptions struct {
 	StoreInVault                     bool `xml:"store-in-vault,omitempty"`
 	AddBillingAddressToPaymentMethod bool `xml:"add-billing-address-to-payment-method,omitempty"`
 	StoreShippingAddressInVault      bool `xml:"store-shipping-address-in-vault,omitempty"`
+	HoldInEscrow                     bool `xml:"hold-in-escrow,omniempty"`
 }
 
 type TransactionSearchResult struct {

--- a/transaction.go
+++ b/transaction.go
@@ -113,7 +113,7 @@ type TransactionOptions struct {
 	StoreInVault                     bool `xml:"store-in-vault,omitempty"`
 	AddBillingAddressToPaymentMethod bool `xml:"add-billing-address-to-payment-method,omitempty"`
 	StoreShippingAddressInVault      bool `xml:"store-shipping-address-in-vault,omitempty"`
-	HoldInEscrow                     bool `xml:"hold-in-escrow,omniempty"`
+	HoldInEscrow                     bool `xml:"hold-in-escrow,omitempty"`
 }
 
 type TransactionSearchResult struct {

--- a/transaction_gateway.go
+++ b/transaction_gateway.go
@@ -75,6 +75,45 @@ func (g *TransactionGateway) Void(id string) (*Transaction, error) {
 	return nil, &invalidResponseError{resp}
 }
 
+// CancelRelease cancels a pending release of a transaction with the given id from escrow.
+func (g *TransactionGateway) CancelRelease(id string) (*Transaction, error) {
+	resp, err := g.execute("PUT", "transactions/"+id+"/cancel_release", nil)
+	if err != nil {
+		return nil, err
+	}
+	switch resp.StatusCode {
+	case 200:
+		return resp.transaction()
+	}
+	return nil, &invalidResponseError{resp}
+}
+
+// ReleaseFromEscrow submits the transaction with the given id for release from escrow.
+func (g *TransactionGateway) ReleaseFromEscrow(id string) (*Transaction, error) {
+	resp, err := g.execute("PUT", "transactions/"+id+"/release_from_escrow", nil)
+	if err != nil {
+		return nil, err
+	}
+	switch resp.StatusCode {
+	case 200:
+		return resp.transaction()
+	}
+	return nil, &invalidResponseError{resp}
+}
+
+// HoldInEscrow holds the transaction with the given id for escrow.
+func (g *TransactionGateway) HoldInEscrow(id string) (*Transaction, error) {
+	resp, err := g.execute("PUT", "transactions/"+id+"/hold_in_escrow", nil)
+	if err != nil {
+		return nil, err
+	}
+	switch resp.StatusCode {
+	case 200:
+		return resp.transaction()
+	}
+	return nil, &invalidResponseError{resp}
+}
+
 // A transaction can be refunded if it is settled or settling.
 // If the transaction has not yet begun settlement, use Void() instead.
 // If you do not specify an amount to refund, the entire transaction amount will be refunded.

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -492,6 +492,7 @@ func TestTransactionCreateSettleAndPartialRefund(t *testing.T) {
 }
 
 func TestHoldInEscrowOnCreate(t *testing.T) {
+	testSubMerchantAccountId := getSubMerchantAccount(t)
 	amount := NewDecimal(6200, 2)
 	txn, err := testGateway.Transaction().Create(&Transaction{
 		Type:   "sale",
@@ -516,6 +517,7 @@ func TestHoldInEscrowOnCreate(t *testing.T) {
 }
 
 func TestHoldInEscrowAfterSale(t *testing.T) {
+	testSubMerchantAccountId := getSubMerchantAccount(t)
 	amount := NewDecimal(6300, 2)
 	txn, err := testGateway.Transaction().Create(&Transaction{
 		Type:   "sale",
@@ -541,6 +543,7 @@ func TestHoldInEscrowAfterSale(t *testing.T) {
 }
 
 func TestReleaseFromEscrow(t *testing.T) {
+	testSubMerchantAccountId := getSubMerchantAccount(t)
 	amount := NewDecimal(6400, 2)
 	txn, err := testGateway.Transaction().Create(&Transaction{
 		Type:   "sale",
@@ -575,6 +578,7 @@ func TestReleaseFromEscrow(t *testing.T) {
 }
 
 func TestCancelRelease(t *testing.T) {
+	testSubMerchantAccountId := getSubMerchantAccount(t)
 	amount := NewDecimal(6500, 2)
 	txn, err := testGateway.Transaction().Create(&Transaction{
 		Type:   "sale",
@@ -623,4 +627,48 @@ func settle(t *testing.T, id string) error {
 		t.Fatalf("expected Status to be submitted_for_settlement, settling, or settled, was %s", txn.Status)
 	}
 	return nil
+}
+
+var subMerchantAccountID string
+
+func getSubMerchantAccount(t *testing.T) string {
+	if subMerchantAccountID == "" {
+		rand.Seed(time.Now().UTC().UnixNano())
+		acctId = rand.Int() + 1
+		acct := MerchantAccount{
+			MasterMerchantAccountId: testMerchantAccountId,
+			TOSAccepted:             true,
+			Id:                      strconv.Itoa(acctId),
+			Individual: &MerchantAccountPerson{
+				FirstName:   "Kayle",
+				LastName:    "Gishen",
+				Email:       "kayle.gishen@example.com",
+				Phone:       "5556789012",
+				DateOfBirth: "1-1-1989",
+				Address: &Address{
+					StreetAddress:   "1 E Main St",
+					ExtendedAddress: "Suite 404",
+					Locality:        "Chicago",
+					Region:          "IL",
+					PostalCode:      "60622",
+				},
+			},
+			FundingOptions: &MerchantAccountFundingOptions{
+				Destination: FUNDING_DEST_MOBILE_PHONE,
+				MobilePhone: "5552344567",
+			},
+		}
+
+		merchantAccount, err := testGateway.MerchantAccount().Create(&acct)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if merchantAccount.Id == "" {
+			t.Fatal("invalid merchant account id")
+		}
+		subMerchantAccountID = merchantAccount.Id
+	}
+	return subMerchantAccountID
 }

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -540,77 +540,77 @@ func TestHoldInEscrowAfterSale(t *testing.T) {
 	}
 }
 
-// func TestReleaseFromEscrow(t *testing.T) {
-// 	amount := NewDecimal(6400, 2)
-// 	txn, err := testGateway.Transaction().Create(&Transaction{
-// 		Type:   "sale",
-// 		Amount: amount,
-// 		CreditCard: &CreditCard{
-// 			Number:         testCreditCards["visa"].Number,
-// 			ExpirationDate: "05/14",
-// 		},
-// 		MerchantAccountId: testSubMerchantAccountId,
-// 		ServiceFeeAmount:  amount,
-// 	})
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	id := txn.Id
-// 	_, err = escrow(id)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	txn, err = testGateway.Transaction().ReleaseFromEscrow(id)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	if txn.EscrowStatus != EscrowStatus.ReleasePending {
-// 		t.Fatalf("expected EscrowStatus to be %s, was %s", EscrowStatus.ReleasePending, txn.EscrowStatus)
-// 	}
-// }
-//
-// func TestCancelRelease(t *testing.T) {
-// 	amount := NewDecimal(6500, 2)
-// 	txn, err := testGateway.Transaction().Create(&Transaction{
-// 		Type:   "sale",
-// 		Amount: amount,
-// 		CreditCard: &CreditCard{
-// 			Number:         testCreditCards["visa"].Number,
-// 			ExpirationDate: "05/14",
-// 		},
-// 		MerchantAccountId: testSubMerchantAccountId,
-// 		ServiceFeeAmount:  amount,
-// 	})
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	t.Logf("merchant url: %s", testGateway.MerchantURL())
-// 	id := txn.Id
-// 	_, err = escrow(id)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	_, err = testGateway.Transaction().ReleaseFromEscrow(id)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	txn, err = testGateway.Transaction().CancelRelease(id)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	if txn.EscrowStatus != EscrowStatus.ReleasePending {
-// 		t.Fatalf("expected EscrowStatus to be %s, was %s", EscrowStatus.ReleasePending, txn.EscrowStatus)
-// 	}
-// }
-//
-// func escrow(id string) (*Transaction, error) {
-// 	resp, err := testGateway.Transaction().execute("PUT", "transactions/"+id+"/escrow", nil)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	switch resp.StatusCode {
-// 	case 200:
-// 		return resp.transaction()
-// 	}
-// 	return nil, &invalidResponseError{resp}
-// }
+func TestReleaseFromEscrow(t *testing.T) {
+	amount := NewDecimal(6400, 2)
+	txn, err := testGateway.Transaction().Create(&Transaction{
+		Type:   "sale",
+		Amount: amount,
+		CreditCard: &CreditCard{
+			Number:         testCreditCards["visa"].Number,
+			ExpirationDate: "05/14",
+		},
+		MerchantAccountId: testSubMerchantAccountId,
+		ServiceFeeAmount:  amount,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := txn.Id
+	_, err = escrow(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txn, err = testGateway.Transaction().ReleaseFromEscrow(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if txn.EscrowStatus != EscrowStatus.ReleasePending {
+		t.Fatalf("expected EscrowStatus to be %s, was %s", EscrowStatus.ReleasePending, txn.EscrowStatus)
+	}
+}
+
+func TestCancelRelease(t *testing.T) {
+	amount := NewDecimal(6500, 2)
+	txn, err := testGateway.Transaction().Create(&Transaction{
+		Type:   "sale",
+		Amount: amount,
+		CreditCard: &CreditCard{
+			Number:         testCreditCards["visa"].Number,
+			ExpirationDate: "05/14",
+		},
+		MerchantAccountId: testSubMerchantAccountId,
+		ServiceFeeAmount:  amount,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("merchant url: %s", testGateway.MerchantURL())
+	id := txn.Id
+	_, err = escrow(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = testGateway.Transaction().ReleaseFromEscrow(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txn, err = testGateway.Transaction().CancelRelease(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if txn.EscrowStatus != EscrowStatus.ReleasePending {
+		t.Fatalf("expected EscrowStatus to be %s, was %s", EscrowStatus.ReleasePending, txn.EscrowStatus)
+	}
+}
+
+func escrow(id string) (*Transaction, error) {
+	resp, err := testGateway.Transaction().execute("PUT", "transactions/"+id+"/escrow", nil)
+	if err != nil {
+		return nil, err
+	}
+	switch resp.StatusCode {
+	case 200:
+		return resp.transaction()
+	}
+	return nil, &invalidResponseError{resp}
+}


### PR DESCRIPTION
Braintree webhooks for notifications sometimes provide multiple payload and signature. This adds support for that. 
Also, braintree returns status 200 for submerchant update. I guess they use to return status 201. 

I suggest all the http statuscode checks be converted to check for anything between 200 and 299 or be changed to check the actual body. 
