### PR TITLE
Add DeviceData to transaction model

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -1,8 +1,9 @@
 package braintree
 
 import (
-	"github.com/lionelbarrow/braintree-go/nullable"
 	"time"
+
+	"github.com/lionelbarrow/braintree-go/nullable"
 )
 
 type Transaction struct {
@@ -21,6 +22,7 @@ type Transaction struct {
 	Customer                   *Customer            `xml:"customer,omitempty"`
 	BillingAddress             *Address             `xml:"billing,omitempty"`
 	ShippingAddress            *Address             `xml:"shipping,omitempty"`
+	DeviceData                 string               `xml:"device_data,omitempty"`
 	Options                    *TransactionOptions  `xml:"options,omitempty"`
 	ServiceFeeAmount           *Decimal             `xml:"service-fee-amount,attr,omitempty"`
 	CreatedAt                  *time.Time           `xml:"created-at,omitempty"`


### PR DESCRIPTION
https://developers.braintreepayments.com/guides/paypal/server-side/ruby#using-device-data

"Collecting device data from your customers is required when initiating non-recurring transactions from Vault records. Collecting and passing this data with transactions will help reduce decline rates."