### PR TITLE
Add DeviceData to transaction model with hyphen

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -1,8 +1,9 @@
 package braintree
 
 import (
-	"github.com/lionelbarrow/braintree-go/nullable"
 	"time"
+
+	"github.com/lionelbarrow/braintree-go/nullable"
 )
 
 type Transaction struct {
@@ -21,6 +22,7 @@ type Transaction struct {
 	Customer                   *Customer            `xml:"customer,omitempty"`
 	BillingAddress             *Address             `xml:"billing,omitempty"`
 	ShippingAddress            *Address             `xml:"shipping,omitempty"`
+	DeviceData                 string               `xml:"device_data,omitempty"`
 	Options                    *TransactionOptions  `xml:"options,omitempty"`
 	ServiceFeeAmount           *Decimal             `xml:"service-fee-amount,attr,omitempty"`
 	CreatedAt                  *time.Time           `xml:"created-at,omitempty"`

--- a/transaction.go
+++ b/transaction.go
@@ -21,7 +21,7 @@ type Transaction struct {
 	Customer                   *Customer            `xml:"customer,omitempty"`
 	BillingAddress             *Address             `xml:"billing,omitempty"`
 	ShippingAddress            *Address             `xml:"shipping,omitempty"`
-	DeviceData                 string               `xml:"device_data,omitempty"`
+	DeviceData                 string               `xml:"device-data,omitempty"`
 	Options                    *TransactionOptions  `xml:"options,omitempty"`
 	ServiceFeeAmount           *Decimal             `xml:"service-fee-amount,attr,omitempty"`
 	CreatedAt                  *time.Time           `xml:"created-at,omitempty"`

--- a/transaction.go
+++ b/transaction.go
@@ -1,9 +1,8 @@
 package braintree
 
 import (
-	"time"
-
 	"github.com/lionelbarrow/braintree-go/nullable"
+	"time"
 )
 
 type Transaction struct {

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -187,6 +187,7 @@ func TestAllTransactionFields(t *testing.T) {
 			Region:        "IL",
 			PostalCode:    "60637",
 		},
+		DeviceData: `{"device_session_id": "dsi_1234", "fraud_merchant_id": "fmi_1234", "correlation_id": "ci_1234"}`,
 		Options: &TransactionOptions{
 			SubmitForSettlement:              true,
 			StoreInVault:                     true,


### PR DESCRIPTION
@lionelbarrow This PR takes the changes @cgcote opened in #76 and:

1. Changes the XML tag to be hyphenated rather than underscored.
2. Adds the field to the `TestAllTransactionFields` integration test using some fields specified [here](http://stackoverflow.com/a/34145834/159762). It's worth noting that adding it doesn't actually test anything, and there's no way to verify that the device data has been communicated correctly because it is not exposed when reading a `Transaction` from the API.

 I looked at the ruby SDK and it does not test the Device Data, so I think this is the best we can do with integration/external only tests.