### PR TITLE
Changed processor code to be a string for uml unmarshalling

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -30,7 +30,7 @@ type Transaction struct {
 	RefundId                   string               `xml:"refund-id,omitempty"`
 	RefundIds                  *[]string            `xml:"refund-ids>item,omitempty"`
 	RefundedTransactionId      *string              `xml:"refunded-transaction-id,omitempty"`
-	ProcessorResponseCode      int                  `xml:"processor-response-code,omitempty"`
+	ProcessorResponseCode      string               `xml:"processor-response-code,omitempty"`
 	ProcessorResponseText      string               `xml:"processor-response-text,omitempty"`
 	ProcessorAuthorizationCode string               `xml:"processor-authorization-code,omitempty"`
 	SettlementBatchId          string               `xml:"settlement-batch-id,omitempty"`


### PR DESCRIPTION
When performing a search of various Braintree transactions that were Gateway Rejected / Processor Declined, I would get an error trying to xml unmarshal the processor response code with a strconv.ParseInt error. 

The xml for the Processor Code can return the following:
<processor-response-code></processor-response-code>

So it makes better sense to change processor-response code to a string instead.