### PR TITLE
Implement payment method gateway

### DIFF
--- a/credit_card.go
+++ b/credit_card.go
@@ -1,8 +1,12 @@
 package braintree
 
-import "time"
+import (
+	"encoding/xml"
+	"time"
+)
 
 type CreditCard struct {
+	XMLName                   xml.Name           `xml:"credit-card`
 	CustomerId                string             `xml:"customer-id,omitempty"`
 	Token                     string             `xml:"token,omitempty"`
 	PaymentMethodNonce        string             `xml:"payment-method-nonce,omitempty"`

--- a/payment_method_gateway.go
+++ b/payment_method_gateway.go
@@ -7,13 +7,22 @@ type PaymentMethodGateway struct {
 }
 
 type PaymentMethodRequest struct {
-	XMLName            xml.Name `xml:"payment-method"`
-	CustomerId         string   `xml:"customer-id,omitempty"`
-	PaymentMethodNonce string   `xml:"payment-method-nonce,omitempty"`
+	XMLName            xml.Name                     `xml:"payment-method"`
+	CustomerId         string                       `xml:"customer-id,omitempty"`
+	Token              string                       `xml:"token,omitempty"`
+	PaymentMethodNonce string                       `xml:"payment-method-nonce,omitempty"`
+	Options            *PaymentMethodRequestOptions `xml:"options,omitempty"`
+}
+
+type PaymentMethodRequestOptions struct {
+	MakeDefault                   bool   `xml:"make-default,omitempty"`
+	FailOnDuplicatePaymentMethod  bool   `xml:"fail-on-duplicate-payment-method,omitempty"`
+	VerifyCard                    bool   `xml:"verify-card,omitempty"`
+	VerificationMerchantAccountId string `xml:"verification-merchant-account-id,omitempty"`
 }
 
 func (g *PaymentMethodGateway) Create(paymentMethodRequest *PaymentMethodRequest) (PaymentMethod, error) {
-	resp, err := g.execute("POST", "payment_methods", paymentMethodRequest)
+	resp, err := g.executeVersion("POST", "payment_methods", paymentMethodRequest, ApiVersion4)
 	if err != nil {
 		return nil, err
 	}
@@ -22,4 +31,40 @@ func (g *PaymentMethodGateway) Create(paymentMethodRequest *PaymentMethodRequest
 		return resp.paymentMethod()
 	}
 	return nil, &invalidResponseError{resp}
+}
+
+func (g *PaymentMethodGateway) Update(token string, paymentMethod *PaymentMethodRequest) (PaymentMethod, error) {
+	resp, err := g.executeVersion("PUT", "payment_methods/any/"+token, paymentMethod, ApiVersion4)
+	if err != nil {
+		return nil, err
+	}
+	switch resp.StatusCode {
+	case 200:
+		return resp.paymentMethod()
+	}
+	return nil, &invalidResponseError{resp}
+}
+
+func (g *PaymentMethodGateway) Find(token string) (PaymentMethod, error) {
+	resp, err := g.executeVersion("GET", "payment_methods/any/"+token, nil, ApiVersion4)
+	if err != nil {
+		return nil, err
+	}
+	switch resp.StatusCode {
+	case 200:
+		return resp.paymentMethod()
+	}
+	return nil, &invalidResponseError{resp}
+}
+
+func (g *PaymentMethodGateway) Delete(token string) error {
+	resp, err := g.executeVersion("DELETE", "payment_methods/any/"+token, nil, ApiVersion4)
+	if err != nil {
+		return err
+	}
+	switch resp.StatusCode {
+	case 200:
+		return nil
+	}
+	return &invalidResponseError{resp}
 }

--- a/payment_method_integration_test.go
+++ b/payment_method_integration_test.go
@@ -1,18 +1,24 @@
 package braintree
 
-import "testing"
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+)
 
-func TestCreatePaymentMethod(t *testing.T) {
+func TestPaymentMethod(t *testing.T) {
 	cust, err := testGateway.Customer().Create(&Customer{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	nonce := FakeNonceTransactable
+	g := testGateway.PaymentMethod()
 
-	paymentMethod, err := testGateway.PaymentMethod().Create(&PaymentMethodRequest{
+	// Create using credit card
+	paymentMethod, err := g.Create(&PaymentMethodRequest{
 		CustomerId:         cust.Id,
-		PaymentMethodNonce: nonce,
+		PaymentMethodNonce: FakeNonceTransactableVisa,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -23,5 +29,73 @@ func TestCreatePaymentMethod(t *testing.T) {
 	}
 	if paymentMethod.GetToken() == "" {
 		t.Errorf("Got paymentMethod token %#v, want a value", paymentMethod.GetToken())
+	}
+
+	// Update using different credit card
+	rand.Seed(time.Now().UTC().UnixNano())
+	token := fmt.Sprintf("btgo_test_token_%d", rand.Int()+1)
+	paymentMethod, err = g.Update(paymentMethod.GetToken(), &PaymentMethodRequest{
+		PaymentMethodNonce: FakeNonceTransactableMasterCard,
+		Token:              token,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if paymentMethod.GetToken() != token {
+		t.Errorf("Got paymentMethod token %#v, want %#v", paymentMethod.GetToken(), token)
+	}
+
+	// Updating with different payment method type should fail
+	if _, err = g.Update(token, &PaymentMethodRequest{PaymentMethodNonce: FakeNoncePayPalFuturePayment}); err == nil {
+		t.Errorf("Updating with a different payment method type should have failed")
+	}
+
+	// Find credit card
+	paymentMethod, err = g.Find(token)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if paymentMethod.GetCustomerId() != cust.Id {
+		t.Errorf("Got paymentMethod customer Id %#v, want %#v", paymentMethod.GetCustomerId(), cust.Id)
+	}
+	if paymentMethod.GetToken() != token {
+		t.Errorf("Got paymentMethod token %#v, want %#v", paymentMethod.GetToken(), token)
+	}
+
+	// Delete credit card
+	if err := g.Delete(token); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create using PayPal
+	paymentMethod, err = g.Create(&PaymentMethodRequest{
+		CustomerId:         cust.Id,
+		PaymentMethodNonce: FakeNoncePayPalFuturePayment,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Find PayPal
+	_, err = g.Find(paymentMethod.GetToken())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Updating a PayPal account with a different payment method nonce of any kind should fail
+	if _, err = g.Update(paymentMethod.GetToken(), &PaymentMethodRequest{PaymentMethodNonce: FakeNoncePayPalOneTimePayment}); err == nil {
+		t.Errorf("Updating a PayPal account with a different nonce should have failed")
+	}
+
+	// Delete PayPal
+	if err := g.Delete(paymentMethod.GetToken()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Cleanup
+	if err := testGateway.Customer().Delete(cust.Id); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/paypal_account.go
+++ b/paypal_account.go
@@ -1,8 +1,12 @@
 package braintree
 
-import "time"
+import (
+	"encoding/xml"
+	"time"
+)
 
 type PayPalAccount struct {
+	XMLName       xml.Name       `xml:"paypal-account"`
 	CustomerId    string         `xml:"customer-id,omitempty"`
 	Token         string         `xml:"token,omitempty"`
 	Email         string         `xml:"email,omitempty"`


### PR DESCRIPTION
This PR builds on top of #44 in order to provide a generic payment method gateway which works with both credit cards and PayPal nonces (similar to the way the latest [Ruby SDK](https://developers.braintreepayments.com/reference/request/payment-method/create/ruby) works).

PS: @maxsz I hope you don't mind that I've used your work for this