### PR TITLE
Add functions for handling default payment methods.

### DIFF
--- a/credit_card.go
+++ b/credit_card.go
@@ -58,6 +58,10 @@ func (card *CreditCard) GetToken() string {
 	return card.Token
 }
 
+func (card *CreditCard) IsDefault() bool {
+	return card.Default
+}
+
 // AllSubscriptions returns all subscriptions for this card, or nil if none present.
 func (card *CreditCard) AllSubscriptions() []*Subscription {
 	if card.Subscriptions != nil {

--- a/customer.go
+++ b/customer.go
@@ -17,11 +17,46 @@ type Customer struct {
 	PayPalAccounts *PayPalAccounts `xml:"paypal-accounts,omitempty"`
 }
 
+// PaymentMethods returns a slice of all PaymentMethods this customer has
+func (c *Customer) PaymentMethods() []PaymentMethod {
+	var paymentMethods []PaymentMethod
+	if c.CreditCards != nil {
+		for _, cc := range c.CreditCards.CreditCard {
+			paymentMethods = append(paymentMethods, cc)
+		}
+	}
+	if c.PayPalAccounts != nil {
+		for _, pp := range c.PayPalAccounts.PayPalAccount {
+			paymentMethods = append(paymentMethods, pp)
+		}
+	}
+	return paymentMethods
+}
+
 // DefaultCreditCard returns the default credit card, or nil
 func (c *Customer) DefaultCreditCard() *CreditCard {
 	for _, card := range c.CreditCards.CreditCard {
 		if card.Default {
 			return card
+		}
+	}
+	return nil
+}
+
+// DefaultPaymentMethod returns the default payment method, or nil
+func (c *Customer) DefaultPaymentMethod() PaymentMethod {
+	if c.CreditCards != nil {
+		for _, cc := range c.CreditCards.CreditCard {
+			if cc.IsDefault() {
+				return cc
+			}
+		}
+	}
+	if c.PayPalAccounts != nil {
+		for _, pp := range c.PayPalAccounts.PayPalAccount {
+			if pp.IsDefault() {
+				return pp
+			}
 		}
 	}
 	return nil

--- a/customer_integration_test.go
+++ b/customer_integration_test.go
@@ -145,3 +145,110 @@ func TestCustomerPayPalAccount(t *testing.T) {
 		t.Fatalf("Got Customer %#v PayPalAccount %#v, want %#v", customerFound, customerFound.PayPalAccounts.PayPalAccount[0], paypalAccount)
 	}
 }
+
+func TestCustomerPaymentMethods(t *testing.T) {
+	customer, err := testGateway.Customer().Create(&Customer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	paymentMethod1, err := testGateway.PaymentMethod().Create(&PaymentMethodRequest{
+		CustomerId:         customer.Id,
+		PaymentMethodNonce: FakeNoncePayPalFuturePayment,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	paymentMethod2, err := testGateway.PaymentMethod().Create(&PaymentMethodRequest{
+		CustomerId:         customer.Id,
+		PaymentMethodNonce: FakeNonceTransactable,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedPaymentMethods := []PaymentMethod{
+		paymentMethod2,
+		paymentMethod1,
+	}
+
+	customerFound, err := testGateway.Customer().Find(customer.Id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(customerFound.PaymentMethods(), expectedPaymentMethods) {
+		t.Fatalf("Got Customer %#v PaymentMethods %#v, want %#v", customerFound, customerFound.PaymentMethods(), expectedPaymentMethods)
+	}
+}
+
+func TestCustomerDefaultPaymentMethod(t *testing.T) {
+	customer, err := testGateway.Customer().Create(&Customer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defaultPaymentMethod, err := testGateway.PaymentMethod().Create(&PaymentMethodRequest{
+		CustomerId:         customer.Id,
+		PaymentMethodNonce: FakeNonceTransactable,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = testGateway.PaymentMethod().Create(&PaymentMethodRequest{
+		CustomerId:         customer.Id,
+		PaymentMethodNonce: FakeNoncePayPalFuturePayment,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	customerFound, err := testGateway.Customer().Find(customer.Id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(customerFound.DefaultPaymentMethod(), defaultPaymentMethod) {
+		t.Fatalf("Got Customer %#v DefaultPaymentMethod %#v, want %#v", customerFound, customerFound.DefaultPaymentMethod(), defaultPaymentMethod)
+	}
+}
+
+func TestCustomerDefaultPaymentMethodManuallySet(t *testing.T) {
+	customer, err := testGateway.Customer().Create(&Customer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = testGateway.PaymentMethod().Create(&PaymentMethodRequest{
+		CustomerId:         customer.Id,
+		PaymentMethodNonce: FakeNonceTransactable,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	paymentMethod2, err := testGateway.PaymentMethod().Create(&PaymentMethodRequest{
+		CustomerId:         customer.Id,
+		PaymentMethodNonce: FakeNoncePayPalFuturePayment,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	paypalAccount, err := testGateway.PayPalAccount().Update(&PayPalAccount{
+		Token: paymentMethod2.GetToken(),
+		Options: &PayPalAccountOptions{
+			MakeDefault: true,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	customerFound, err := testGateway.Customer().Find(customer.Id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(customerFound.DefaultPaymentMethod(), paypalAccount) {
+		t.Fatalf("Got Customer %#v DefaultPaymentMethod %#v, want %#v", customerFound, customerFound.DefaultPaymentMethod(), paypalAccount)
+	}
+}

--- a/payment_method.go
+++ b/payment_method.go
@@ -3,4 +3,5 @@ package braintree
 type PaymentMethod interface {
 	GetCustomerId() string
 	GetToken() string
+	IsDefault() bool
 }

--- a/paypal_account.go
+++ b/paypal_account.go
@@ -3,17 +3,23 @@ package braintree
 import "time"
 
 type PayPalAccount struct {
-	CustomerId    string         `xml:"customer-id,omitempty"`
-	Token         string         `xml:"token,omitempty"`
-	Email         string         `xml:"email,omitempty"`
-	ImageURL      string         `xml:"image-url,omitempty"`
-	CreatedAt     *time.Time     `xml:"created-at,omitempty"`
-	UpdatedAt     *time.Time     `xml:"updated-at,omitempty"`
-	Subscriptions *Subscriptions `xml:"subscriptions,omitempty"`
+	CustomerId    string                `xml:"customer-id,omitempty"`
+	Token         string                `xml:"token,omitempty"`
+	Email         string                `xml:"email,omitempty"`
+	ImageURL      string                `xml:"image-url,omitempty"`
+	CreatedAt     *time.Time            `xml:"created-at,omitempty"`
+	UpdatedAt     *time.Time            `xml:"updated-at,omitempty"`
+	Subscriptions *Subscriptions        `xml:"subscriptions,omitempty"`
+	Default       bool                  `xml:"default,omitempty"`
+	Options       *PayPalAccountOptions `xml:"options,omitempty"`
 }
 
 type PayPalAccounts struct {
 	PayPalAccount []*PayPalAccount `xml:"paypal-account"`
+}
+
+type PayPalAccountOptions struct {
+	MakeDefault bool `xml:"make-default,omitempty"`
 }
 
 func (paypalAccount *PayPalAccount) GetCustomerId() string {
@@ -22,6 +28,10 @@ func (paypalAccount *PayPalAccount) GetCustomerId() string {
 
 func (paypalAccount *PayPalAccount) GetToken() string {
 	return paypalAccount.Token
+}
+
+func (paypalAccount *PayPalAccount) IsDefault() bool {
+	return paypalAccount.Default
 }
 
 // AllSubscriptions returns all subscriptions for this paypal account, or nil if none present.


### PR DESCRIPTION
What
===
Add functions and fields for handling multiple and default payment methods:

* Add `PayPalAccountOptions` with `MakeDefault` as a field for setting a `PayPalAccount` to be a `Customer`s default payment method.
* Add `IsDefault()` to the `PaymentMethod` interface.
* Add `PaymentMethods()` to `Customer`.
* Add `DefaultPaymentMethod()` to `Customer`.

Why
===
Now that a `Customer` has multiple payment method types (`CreditCard` and `PayPalAccount`) we need to be able to discover the default payment method, because `Customer` only exposes the default credit card.