### PR TITLE
Add a common GetImageURL to PaymentMethods

### DIFF
--- a/credit_card.go
+++ b/credit_card.go
@@ -58,6 +58,10 @@ func (card *CreditCard) GetToken() string {
 	return card.Token
 }
 
+func (card *CreditCard) GetImageURL() string {
+	return card.ImageURL
+}
+
 // AllSubscriptions returns all subscriptions for this card, or nil if none present.
 func (card *CreditCard) AllSubscriptions() []*Subscription {
 	if card.Subscriptions != nil {

--- a/payment_method.go
+++ b/payment_method.go
@@ -3,4 +3,5 @@ package braintree
 type PaymentMethod interface {
 	GetCustomerId() string
 	GetToken() string
+	GetImageURL() string
 }

--- a/paypal_account.go
+++ b/paypal_account.go
@@ -24,6 +24,10 @@ func (paypalAccount *PayPalAccount) GetToken() string {
 	return paypalAccount.Token
 }
 
+func (paypalAccount *PayPalAccount) GetImageURL() string {
+	return paypalAccount.ImageURL
+}
+
 // AllSubscriptions returns all subscriptions for this paypal account, or nil if none present.
 func (paypalAccount *PayPalAccount) AllSubscriptions() []*Subscription {
 	if paypalAccount.Subscriptions != nil {


### PR DESCRIPTION
What
===
Add a common `GetImageURL()` to `PaymentMethod`s.

Why
===
The function is included in the `PaymentMethod` interface in other SDKs,
and all payment methods have an `ImageURL` field.