### PR TITLE
Add PayPalDetails to Transactions

### DIFF
--- a/paypal_details.go
+++ b/paypal_details.go
@@ -1,0 +1,22 @@
+package braintree
+
+type PayPalDetails struct {
+	PayerEmail                    string `xml:"payer-email,omitempty"`
+	PaymentID                     string `xml:"payment-id,omitempty"`
+	AuthorizationID               string `xml:"authorization-id,omitempty"`
+	Token                         string `xml:"token,omitempty"`
+	ImageURL                      string `xml:"image-url,omitempty"`
+	DebugID                       string `xml:"debug-id,omitempty"`
+	PayeeEmail                    string `xml:"payee-email,omitempty"`
+	CustomField                   string `xml:"custom-field,omitempty"`
+	PayerID                       string `xml:"payer-id,omitempty"`
+	PayerFirstName                string `xml:"payer-first-name,omitempty"`
+	PayerLastName                 string `xml:"payer-last-name,omitempty"`
+	PayerStatus                   string `xml:"payer-status,omitempty"`
+	SellerProtectionStatus        string `xml:"seller-protection-status,omitempty"`
+	RefundID                      string `xml:"refund-id,omitempty"`
+	CaptureID                     string `xml:"capture-id,omitempty"`
+	TransactionFeeAmount          string `xml:"transaction-fee-amount,omitempty"`
+	TransactionFeeCurrencyISOCode string `xml:"transaction-fee-currency-iso-code,omitempty"`
+	Description                   string `xml:"description,omitempty"`
+}

--- a/transaction.go
+++ b/transaction.go
@@ -1,8 +1,9 @@
 package braintree
 
 import (
-	"github.com/lionelbarrow/braintree-go/nullable"
 	"time"
+
+	"github.com/lionelbarrow/braintree-go/nullable"
 )
 
 type Transaction struct {
@@ -34,6 +35,7 @@ type Transaction struct {
 	ProcessorResponseText      string               `xml:"processor-response-text,omitempty"`
 	ProcessorAuthorizationCode string               `xml:"processor-authorization-code,omitempty"`
 	SettlementBatchId          string               `xml:"settlement-batch-id,omitempty"`
+	PayPalDetails              *PayPalDetails       `xml:"paypal,omitempty"`
 }
 
 // TODO: not all transaction fields are implemented yet, here are the missing fields (add on demand)

--- a/transaction_paypal_details_integration_test.go
+++ b/transaction_paypal_details_integration_test.go
@@ -1,0 +1,81 @@
+package braintree
+
+import "testing"
+
+func TestTransactionPayPalDetails(t *testing.T) {
+	tx, err := testGateway.Transaction().Create(&Transaction{
+		Type:               "sale",
+		Amount:             NewDecimal(2000, 2),
+		PaymentMethodNonce: FakeNoncePayPalOneTimePayment,
+	})
+
+	t.Log(tx)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tx.Id == "" {
+		t.Fatal("Received invalid ID on new transaction")
+	}
+	if tx.Status != "authorized" {
+		t.Fatal(tx.Status)
+	}
+
+	if tx.PayPalDetails == nil {
+		t.Fatal("Expected PayPalDetails for transaction created with PayPal nonce")
+	}
+
+	t.Log(tx.PayPalDetails)
+
+	if tx.PayPalDetails.PayerEmail == "" {
+		t.Fatal("Expected PayPalDetails to have PayerEmail set")
+	}
+	if tx.PayPalDetails.PaymentID == "" {
+		t.Fatal("Expected PayPalDetails to have PaymentID set")
+	}
+	if tx.PayPalDetails.ImageURL == "" {
+		t.Fatal("Expected PayPalDetails to have ImageURL set")
+	}
+	if tx.PayPalDetails.DebugID == "" {
+		t.Fatal("Expected PayPalDetails to have DebugID set")
+	}
+	if tx.PayPalDetails.PayerID == "" {
+		t.Fatal("Expected PayPalDetails to have DebugID set")
+	}
+	if tx.PayPalDetails.PayerFirstName == "" {
+		t.Fatal("Expected PayPalDetails to have PayerFirstName set")
+	}
+	if tx.PayPalDetails.PayerLastName == "" {
+		t.Fatal("Expected PayPalDetails to have PayerLastName set")
+	}
+	if tx.PayPalDetails.PayerStatus == "" {
+		t.Fatal("Expected PayPalDetails to have PayerStatus set")
+	}
+	if tx.PayPalDetails.SellerProtectionStatus == "" {
+		t.Fatal("Expected PayPalDetails to have SellerProtectionStatus set")
+	}
+}
+
+func TestTransactionWithoutPayPalDetails(t *testing.T) {
+	tx, err := testGateway.Transaction().Create(&Transaction{
+		Type:               "sale",
+		Amount:             NewDecimal(2000, 2),
+		PaymentMethodNonce: FakeNonceTransactable,
+	})
+
+	t.Log(tx)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tx.Id == "" {
+		t.Fatal("Received invalid ID on new transaction")
+	}
+	if tx.Status != "authorized" {
+		t.Fatal(tx.Status)
+	}
+
+	if tx.PayPalDetails != nil {
+		t.Fatalf("Expected PayPalDetails to be nil for transaction created without PayPal, but was %#v", tx.PayPalDetails)
+	}
+}


### PR DESCRIPTION
What
===
Add `PayPalDetails` to `Transaction`.

Why
===
When `Transaction`s are created with a PayPal nonce or `PayPalAccount`
the details are not visible on the resulting `Transaction`.