### PR TITLE
Fix the flaky settlement summary test

### DIFF
--- a/settlement_integration_test.go
+++ b/settlement_integration_test.go
@@ -3,6 +3,7 @@ package braintree
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -84,6 +85,8 @@ func TestSettlementBatch(t *testing.T) {
 	for _, record := range batchSummary.Records.Type {
 		foundTypes = append(foundTypes, record.CardType)
 	}
+	sort.Strings(cardTypes)
+	sort.Strings(foundTypes)
 	if !reflect.DeepEqual(cardTypes, foundTypes) {
 		t.Fatal(fmt.Sprintf("Expected card types: %s, got: %s", cardTypes, foundTypes))
 	}


### PR DESCRIPTION
What
===
Sort the results that get compared at the end of the settlement summary
test, before they are compared.

Why
===
Sometimes the results come back in different orders. The order doesn't
matter, we just want to check that the items are the same and sorting
them will ensure the tests passes even if they come back in a different
order.