### PR TITLE
Add additional processor response and risk data

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -52,9 +52,6 @@ type Transaction struct {
 //   <avs-street-address-response-code>I</avs-street-address-response-code>
 //   <cvv-response-code>I</cvv-response-code>
 //   <gateway-rejection-reason nil="true"></gateway-rejection-reason>
-//   <processor-response-code>2001</processor-response-code>
-//   <processor-response-text>Insufficient Funds</processor-response-text>
-//   <additional-processor-response>2001 : Insufficient Funds</additional-processor-response>
 //   <voice-referral-number nil="true"></voice-referral-number>
 //   <purchase-order-number nil="true"></purchase-order-number>
 //   <tax-amount nil="true"></tax-amount>
@@ -97,11 +94,6 @@ type Transaction struct {
 //   <recurring type="boolean">true</recurring>
 //   <channel nil="true"></channel>
 //   <escrow-status nil="true"></escrow-status>
-//   <payment-instrument-type>credit_card</payment-instrument-type>
-//   <risk-data>
-//     <id>PNMN0WDTT35J</id>
-//     <decision>Approve</decision>
-//   </risk-data>
 // </transaction>
 
 type Transactions struct {

--- a/transaction.go
+++ b/transaction.go
@@ -38,7 +38,7 @@ type Transaction struct {
 	PaymentInstrumentType       string               `xml:"payment-instrument-type,omitempty"`
 	PayPalDetails               *PayPalDetails       `xml:"paypal,omitempty"`
 	AdditionalProcessorResponse string               `xml:"additional-processor-response,omitempty"`
-	RiskData                    *RiskData            `xml:"risk-data"`
+	RiskData                    *RiskData            `xml:"risk-data,omitempty"`
 }
 
 // TODO: not all transaction fields are implemented yet, here are the missing fields (add on demand)

--- a/transaction.go
+++ b/transaction.go
@@ -7,36 +7,38 @@ import (
 )
 
 type Transaction struct {
-	XMLName                    string               `xml:"transaction"`
-	Id                         string               `xml:"id,omitempty"`
-	CustomerID                 string               `xml:"customer-id,omitempty"`
-	Status                     string               `xml:"status,omitempty"`
-	Type                       string               `xml:"type,omitempty"`
-	Amount                     *Decimal             `xml:"amount"`
-	OrderId                    string               `xml:"order-id,omitempty"`
-	PaymentMethodToken         string               `xml:"payment-method-token,omitempty"`
-	PaymentMethodNonce         string               `xml:"payment-method-nonce,omitempty"`
-	MerchantAccountId          string               `xml:"merchant-account-id,omitempty"`
-	PlanId                     string               `xml:"plan-id,omitempty"`
-	CreditCard                 *CreditCard          `xml:"credit-card,omitempty"`
-	Customer                   *Customer            `xml:"customer,omitempty"`
-	BillingAddress             *Address             `xml:"billing,omitempty"`
-	ShippingAddress            *Address             `xml:"shipping,omitempty"`
-	DeviceData                 string               `xml:"device-data,omitempty"`
-	Options                    *TransactionOptions  `xml:"options,omitempty"`
-	ServiceFeeAmount           *Decimal             `xml:"service-fee-amount,attr,omitempty"`
-	CreatedAt                  *time.Time           `xml:"created-at,omitempty"`
-	UpdatedAt                  *time.Time           `xml:"updated-at,omitempty"`
-	DisbursementDetails        *DisbursementDetails `xml:"disbursement-details,omitempty"`
-	RefundId                   string               `xml:"refund-id,omitempty"`
-	RefundIds                  *[]string            `xml:"refund-ids>item,omitempty"`
-	RefundedTransactionId      *string              `xml:"refunded-transaction-id,omitempty"`
-	ProcessorResponseCode      int                  `xml:"processor-response-code,omitempty"`
-	ProcessorResponseText      string               `xml:"processor-response-text,omitempty"`
-	ProcessorAuthorizationCode string               `xml:"processor-authorization-code,omitempty"`
-	SettlementBatchId          string               `xml:"settlement-batch-id,omitempty"`
-	PaymentInstrumentType      string               `xml:"payment-instrument-type,omitempty"`
-	PayPalDetails              *PayPalDetails       `xml:"paypal,omitempty"`
+	XMLName                     string               `xml:"transaction"`
+	Id                          string               `xml:"id,omitempty"`
+	CustomerID                  string               `xml:"customer-id,omitempty"`
+	Status                      string               `xml:"status,omitempty"`
+	Type                        string               `xml:"type,omitempty"`
+	Amount                      *Decimal             `xml:"amount"`
+	OrderId                     string               `xml:"order-id,omitempty"`
+	PaymentMethodToken          string               `xml:"payment-method-token,omitempty"`
+	PaymentMethodNonce          string               `xml:"payment-method-nonce,omitempty"`
+	MerchantAccountId           string               `xml:"merchant-account-id,omitempty"`
+	PlanId                      string               `xml:"plan-id,omitempty"`
+	CreditCard                  *CreditCard          `xml:"credit-card,omitempty"`
+	Customer                    *Customer            `xml:"customer,omitempty"`
+	BillingAddress              *Address             `xml:"billing,omitempty"`
+	ShippingAddress             *Address             `xml:"shipping,omitempty"`
+	DeviceData                  string               `xml:"device-data,omitempty"`
+	Options                     *TransactionOptions  `xml:"options,omitempty"`
+	ServiceFeeAmount            *Decimal             `xml:"service-fee-amount,attr,omitempty"`
+	CreatedAt                   *time.Time           `xml:"created-at,omitempty"`
+	UpdatedAt                   *time.Time           `xml:"updated-at,omitempty"`
+	DisbursementDetails         *DisbursementDetails `xml:"disbursement-details,omitempty"`
+	RefundId                    string               `xml:"refund-id,omitempty"`
+	RefundIds                   *[]string            `xml:"refund-ids>item,omitempty"`
+	RefundedTransactionId       *string              `xml:"refunded-transaction-id,omitempty"`
+	ProcessorResponseCode       int                  `xml:"processor-response-code,omitempty"`
+	ProcessorResponseText       string               `xml:"processor-response-text,omitempty"`
+	ProcessorAuthorizationCode  string               `xml:"processor-authorization-code,omitempty"`
+	SettlementBatchId           string               `xml:"settlement-batch-id,omitempty"`
+	PaymentInstrumentType       string               `xml:"payment-instrument-type,omitempty"`
+	PayPalDetails               *PayPalDetails       `xml:"paypal,omitempty"`
+	AdditionalProcessorResponse string               `xml:"additional-processor-response,omitempty"`
+	RiskData                    *RiskData            `xml:"risk-data"`
 }
 
 // TODO: not all transaction fields are implemented yet, here are the missing fields (add on demand)
@@ -50,6 +52,9 @@ type Transaction struct {
 //   <avs-street-address-response-code>I</avs-street-address-response-code>
 //   <cvv-response-code>I</cvv-response-code>
 //   <gateway-rejection-reason nil="true"></gateway-rejection-reason>
+//   <processor-response-code>2001</processor-response-code>
+//   <processor-response-text>Insufficient Funds</processor-response-text>
+//   <additional-processor-response>2001 : Insufficient Funds</additional-processor-response>
 //   <voice-referral-number nil="true"></voice-referral-number>
 //   <purchase-order-number nil="true"></purchase-order-number>
 //   <tax-amount nil="true"></tax-amount>
@@ -92,6 +97,11 @@ type Transaction struct {
 //   <recurring type="boolean">true</recurring>
 //   <channel nil="true"></channel>
 //   <escrow-status nil="true"></escrow-status>
+//   <payment-instrument-type>credit_card</payment-instrument-type>
+//   <risk-data>
+//     <id>PNMN0WDTT35J</id>
+//     <decision>Approve</decision>
+//   </risk-data>
 // </transaction>
 
 type Transactions struct {
@@ -111,4 +121,9 @@ type TransactionSearchResult struct {
 	PageSize          *nullable.NullInt64 `xml:"page-size"`
 	TotalItems        *nullable.NullInt64 `xml:"total-items"`
 	Transactions      []*Transaction      `xml:"transaction"`
+}
+
+type RiskData struct {
+	ID       string `xml:"id"`
+	Decision string `xml:"decision"`
 }

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -127,6 +127,13 @@ func TestTransactionCreateWhenGatewayRejected(t *testing.T) {
 	if err.Error() != "Card Issuer Declined CVV" {
 		t.Fatal(err)
 	}
+	if err.(*BraintreeError).Transaction.ProcessorResponseCode != 2010 {
+		t.Fatalf("expected err.Transaction.ProcessorResponseCode to be 2010, but got %s", err.(*BraintreeError).Transaction.ProcessorResponseCode)
+	}
+
+	if err.(*BraintreeError).Transaction.AdditionalProcessorResponse != "2010 : Card Issuer Declined CVV" {
+		t.Fatalf("expected err.Transaction.ProcessorResponseCode to be `2010 : Card Issuer Declined CVV`, but got %s", err.(*BraintreeError).Transaction.AdditionalProcessorResponse)
+	}
 }
 
 func TestFindTransaction(t *testing.T) {
@@ -248,6 +255,18 @@ func TestAllTransactionFields(t *testing.T) {
 	}
 	if tx2.PaymentInstrumentType != "credit_card" {
 		t.Fatalf("expected tx2.PaymentInstrumentType to be %s, but got %s", "credit_card", tx2.PaymentInstrumentType)
+	}
+	if tx2.AdditionalProcessorResponse != "" {
+		t.Fatalf("expected tx2.AdditionalProcessorResponse to be empty, but got %s", tx2.AdditionalProcessorResponse)
+	}
+	if tx2.RiskData == nil {
+		t.Fatal("expected tx2.RiskData not to be empty")
+	}
+	if tx2.RiskData.ID == "" {
+		t.Fatal("expected tx2.RiskData.ID not to be empty")
+	}
+	if tx2.RiskData.Decision != "Approve" {
+		t.Fatalf("expected tx2.RiskData.Decision to be Approve, but got %s", tx2.RiskData.Decision)
 	}
 }
 


### PR DESCRIPTION
What
===
Add additional processor response and risk data to `Transaction`.

Why
===
The fields are not yet unmarshalled out of the xml into the `Transaction` struct and they were proposed in #63.