### PR TITLE
Fix go vet and make travis run it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ env:
 
 go_import_path: github.com/lionelbarrow/braintree-go
 
-test:
+script:
   - go vet ./...
   - go test -v ./...

--- a/credit_card.go
+++ b/credit_card.go
@@ -6,7 +6,7 @@ import (
 )
 
 type CreditCard struct {
-	XMLName                   xml.Name           `xml:"credit-card`
+	XMLName                   xml.Name           `xml:"credit-card"`
 	CustomerId                string             `xml:"customer-id,omitempty"`
 	Token                     string             `xml:"token,omitempty"`
 	PaymentMethodNonce        string             `xml:"payment-method-nonce,omitempty"`

--- a/nullable/types_test.go
+++ b/nullable/types_test.go
@@ -31,7 +31,7 @@ func TestNullInt64UnmarshalText(t *testing.T) {
 		}
 
 		if n != tt.out {
-			t.Errorf("UnmarshalText(%q) => %q, want %q", tt.in, n, tt.out)
+			t.Errorf("UnmarshalText(%q) => %v, want %v", tt.in, n, tt.out)
 		}
 	}
 }
@@ -49,7 +49,7 @@ func TestNullInt64MarshalText(t *testing.T) {
 		b, err := tt.in.MarshalText()
 
 		if !bytes.Equal(b, tt.out) || err != nil {
-			t.Errorf("%q.MarshalText() => (%s, %s), want (%s, %s)", tt.in, b, err, tt.out, nil)
+			t.Errorf("%v.MarshalText() => (%s, %s), want (%s, %v)", tt.in, b, err, tt.out, nil)
 		}
 	}
 }
@@ -80,7 +80,7 @@ func TestNullBoolUnmarshalText(t *testing.T) {
 		}
 
 		if n != tt.out {
-			t.Errorf("UnmarshalText(%q) => %q, want %q", tt.in, n, tt.out)
+			t.Errorf("UnmarshalText(%q) => %v, want %v", tt.in, n, tt.out)
 		}
 	}
 }
@@ -98,7 +98,7 @@ func TestNullBoolMarshalText(t *testing.T) {
 		b, err := tt.in.MarshalText()
 
 		if !bytes.Equal(b, tt.out) || err != nil {
-			t.Errorf("%q.MarshalText() => (%s, %s), want (%s, %s)", tt.in, b, err, tt.out, nil)
+			t.Errorf("%v.MarshalText() => (%s, %s), want (%s, %v)", tt.in, b, err, tt.out, nil)
 		}
 	}
 }

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -128,7 +128,7 @@ func TestTransactionCreateWhenGatewayRejected(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err.(*BraintreeError).Transaction.ProcessorResponseCode != 2010 {
-		t.Fatalf("expected err.Transaction.ProcessorResponseCode to be 2010, but got %s", err.(*BraintreeError).Transaction.ProcessorResponseCode)
+		t.Fatalf("expected err.Transaction.ProcessorResponseCode to be 2010, but got %d", err.(*BraintreeError).Transaction.ProcessorResponseCode)
 	}
 
 	if err.(*BraintreeError).Transaction.AdditionalProcessorResponse != "2010 : Card Issuer Declined CVV" {


### PR DESCRIPTION
Fix all the cases that `go vet` errors on, and fixed `.travis.yml` so that it actually runs it. In `.travis.yml` there's a `test` section that should be named `script`. Because it's incorrectly named it's being ignored and `go vet` isn't being run.

Most of the cases getting fixed were incorrect string format options for the type being passed in because the type was an int and being printed as a string, or a struct and being printed as a character.