### PR TITLE
Unmarshal Addons and Discounts for a Plan (extended)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -22,7 +22,7 @@ In your sandbox account go to `Settings > Processing > CVV` and enable the follo
   1. `CVV does not match (when provided) (N)` to `For Any Transaction`
   2. `CVV is not verified (when provided) (U)` to `For Any Transaction`
 
-Finally you will also need to create a transaction with a specific id, two plans, an add-on, and a discount. Once you do all of these things, the integration tests should all pass, with the one exception listed below.
+Finally you will also need to create a transaction with a specific id, two plans, an add-on, and a discount, with the the add on and discount associated with the first plan. Once you do all of these things, the integration tests should all pass, with the one exception listed below.
 
 **Transactions**
 

--- a/plan.go
+++ b/plan.go
@@ -9,13 +9,11 @@ import (
 type Plan struct {
 	XMLName               string              `xml:"plan"`
 	Id                    string              `xml:"id"`
-	AddOns                AddOnList           `xml:"add-ons"`
 	MerchantId            string              `xml:"merchant-id"`
 	BillingDayOfMonth     *nullable.NullInt64 `xml:"billing-day-of-month"`
 	BillingFrequency      *nullable.NullInt64 `xml:"billing-frequency"`
 	CurrencyISOCode       string              `xml:"currency-iso-code"`
 	Description           string              `xml:"description"`
-	Discounts             DiscountList        `xml:"discounts"`
 	Name                  string              `xml:"name"`
 	NumberOfBillingCycles *nullable.NullInt64 `xml:"number-of-billing-cycles"`
 	Price                 *Decimal            `xml:"price"`
@@ -24,6 +22,8 @@ type Plan struct {
 	TrialPeriod           *nullable.NullBool  `xml:"trial-period"`
 	CreatedAt             *time.Time          `xml:"created-at"`
 	UpdatedAt             *time.Time          `xml:"updated-at"`
+	AddOns                AddOnList           `xml:"add-ons"`
+	Discounts             DiscountList        `xml:"discounts"`
 }
 
 type Plans struct {

--- a/plan.go
+++ b/plan.go
@@ -1,20 +1,21 @@
 package braintree
 
 import (
-	"github.com/lionelbarrow/braintree-go/nullable"
 	"time"
+
+	"github.com/lionelbarrow/braintree-go/nullable"
 )
 
 type Plan struct {
-	XMLName               string `xml:"plan"`
-	Id                    string `xml:"id"`
-	AddOns                AddOnList
+	XMLName               string              `xml:"plan"`
+	Id                    string              `xml:"id"`
+	AddOns                AddOnList           `xml:"add-ons"`
 	MerchantId            string              `xml:"merchant-id"`
 	BillingDayOfMonth     *nullable.NullInt64 `xml:"billing-day-of-month"`
 	BillingFrequency      *nullable.NullInt64 `xml:"billing-frequency"`
 	CurrencyISOCode       string              `xml:"currency-iso-code"`
 	Description           string              `xml:"description"`
-	Discounts             DiscountList
+	Discounts             DiscountList        `xml:"discounts"`
 	Name                  string              `xml:"name"`
 	NumberOfBillingCycles *nullable.NullInt64 `xml:"number-of-billing-cycles"`
 	Price                 *Decimal            `xml:"price"`

--- a/plan.go
+++ b/plan.go
@@ -22,8 +22,8 @@ type Plan struct {
 	TrialPeriod           *nullable.NullBool  `xml:"trial-period"`
 	CreatedAt             *time.Time          `xml:"created-at"`
 	UpdatedAt             *time.Time          `xml:"updated-at"`
-	AddOns                AddOnList           `xml:"add-ons"`
-	Discounts             DiscountList        `xml:"discounts"`
+	AddOns                *AddOnList          `xml:"add-ons"`
+	Discounts             *DiscountList       `xml:"discounts"`
 }
 
 type Plans struct {

--- a/plan.go
+++ b/plan.go
@@ -22,8 +22,8 @@ type Plan struct {
 	TrialPeriod           *nullable.NullBool  `xml:"trial-period"`
 	CreatedAt             *time.Time          `xml:"created-at"`
 	UpdatedAt             *time.Time          `xml:"updated-at"`
-	AddOns                *AddOnList          `xml:"add-ons"`
-	Discounts             *DiscountList       `xml:"discounts"`
+	AddOns                AddOnList           `xml:"add-ons"`
+	Discounts             DiscountList        `xml:"discounts"`
 }
 
 type Plans struct {

--- a/plan_integration_test.go
+++ b/plan_integration_test.go
@@ -68,6 +68,46 @@ func TestPlan(t *testing.T) {
 		t.Fatal(x)
 	}
 
+	// Add Ons
+	if plan.AddOns == nil || len(plan.AddOns.AddOns) == 0 {
+		t.Fatal(plan.AddOns)
+	}
+	addOn := plan.AddOns.AddOns[0]
+	t.Log(addOn)
+	if addOn.Id != "test_add_on" {
+		t.Fatalf("expected Id to be %s, was %s", "test_add_on", addOn.Id)
+	} else if addOn.Amount.Cmp(NewDecimal(1000, 2)) != 0 {
+		t.Fatalf("expected Amount to be %s, was %s", NewDecimal(1000, 2), addOn.Amount)
+	} else if addOn.Kind != ModificationKindAddOn {
+		t.Fatalf("expected Kind to be %s, was %s", ModificationKindAddOn, addOn.Kind)
+	} else if addOn.Name != "test_add_on_name" {
+		t.Fatalf("expected Name to be %s, was %s", "test_add_on_name", addOn.Name)
+	} else if addOn.NeverExpires != true {
+		t.Fatalf("expected NeverExpires to be %v, was %v", true, addOn.NeverExpires)
+	} else if addOn.Description != "A test add-on" {
+		t.Fatalf("expected Description to be %s, was %s", "A test add-on", addOn.Description)
+	}
+
+	// Discounts
+	if plan.Discounts == nil || len(plan.Discounts.Discounts) == 0 {
+		t.Fatal(plan.Discounts)
+	}
+	discount := plan.Discounts.Discounts[0]
+	t.Log(discount)
+	if discount.Id != "test_discount" {
+		t.Fatalf("expected Id to be %s, was %s", "test_discount", discount.Id)
+	} else if discount.Amount.Cmp(NewDecimal(1000, 2)) != 0 {
+		t.Fatalf("expected Amount to be %s, was %s", NewDecimal(1000, 2), discount.Amount)
+	} else if discount.Kind != ModificationKindDiscount {
+		t.Fatalf("expected Kind to be %s, was %s", ModificationKindDiscount, discount.Kind)
+	} else if discount.Name != "test_discount_name" {
+		t.Fatalf("expected Name to be %s, was %s", "test_discount_name", discount.Name)
+	} else if discount.NeverExpires != true {
+		t.Fatalf("expected NeverExpires to be %v, was %v", true, discount.NeverExpires)
+	} else if discount.Description != "A test discount" {
+		t.Fatalf("expected Description to be %s, was %s", "A test discount", discount.Description)
+	}
+
 	// Find
 	plan2, err := g.Find("test_plan_2")
 	if err != nil {
@@ -75,5 +115,11 @@ func TestPlan(t *testing.T) {
 	}
 	if plan2.Id != "test_plan_2" {
 		t.Fatal(plan2)
+	}
+	if len(plan2.AddOns.AddOns) != 0 {
+		t.Fatal(plan2.AddOns)
+	}
+	if len(plan2.Discounts.Discounts) != 0 {
+		t.Fatal(plan2.Discounts)
 	}
 }

--- a/plan_integration_test.go
+++ b/plan_integration_test.go
@@ -69,7 +69,7 @@ func TestPlan(t *testing.T) {
 	}
 
 	// Add Ons
-	if plan.AddOns == nil || len(plan.AddOns.AddOns) == 0 {
+	if len(plan.AddOns.AddOns) == 0 {
 		t.Fatal(plan.AddOns)
 	}
 	addOn := plan.AddOns.AddOns[0]
@@ -89,7 +89,7 @@ func TestPlan(t *testing.T) {
 	}
 
 	// Discounts
-	if plan.Discounts == nil || len(plan.Discounts.Discounts) == 0 {
+	if len(plan.Discounts.Discounts) == 0 {
 		t.Fatal(plan.Discounts)
 	}
 	discount := plan.Discounts.Discounts[0]


### PR DESCRIPTION
This PR extends #93 adding tests to check that they are unmarshalled correctly within a `Plan`.

I associated the existing `test_add_on` and `test_discount` with `test_plan` so that when retrieving the plan we can test the presence and unmarshalling of the add on and discount.