### PR TITLE
Add descriptor to Transactions and Subscriptions

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -22,6 +22,8 @@ In your sandbox account go to `Settings > Processing > CVV` and enable the follo
   1. `CVV does not match (when provided) (N)` to `For Any Transaction`
   2. `CVV is not verified (when provided) (U)` to `For Any Transaction`
 
+Your sandbox account will also need to be enabled for dynamic descriptors for the transaction dynamic descriptor tests to pass. See the [Braintree docs](https://articles.braintreepayments.com/control-panel/transactions/descriptors).
+
 Finally you will also need to create a transaction with a specific id, two plans, an add-on, and a discount, with the the add on and discount associated with the first plan. Once you do all of these things, the integration tests should all pass, with the one exception listed below.
 
 **Transactions**

--- a/descriptor.go
+++ b/descriptor.go
@@ -1,0 +1,7 @@
+package braintree
+
+type Descriptor struct {
+	Name  string `xml:"name,omitempty"`
+	Phone string `xml:"phone,omitempty"`
+	URL   string `xml:"url,omitempty"`
+}

--- a/subscription.go
+++ b/subscription.go
@@ -44,8 +44,8 @@ type Subscription struct {
 	TrialPeriod             *nullable.NullBool   `xml:"trial-period,omitempty"`
 	Transactions            *Transactions        `xml:"transactions,omitempty"`
 	Options                 *SubscriptionOptions `xml:"options,omitempty"`
+	Descriptor              *Descriptor          `xml:"descriptor,omitempty"`
 	// AddOns                  []interface{} `xml:"add-ons,omitempty"`
-	// Descriptor              interface{}   `xml:"descriptor,omitempty"`   // struct with name, phone
 }
 
 type SubscriptionRequest struct {
@@ -65,6 +65,7 @@ type SubscriptionRequest struct {
 	TrialDuration         string               `xml:"trial-duration,omitempty"`
 	TrialDurationUnit     string               `xml:"trial-duration-unit,omitempty"`
 	TrialPeriod           *nullable.NullBool   `xml:"trial-period,omitempty"`
+	Descriptor            *Descriptor          `xml:"descriptor,omitempty"`
 }
 
 type Subscriptions struct {

--- a/subscription_integration_test.go
+++ b/subscription_integration_test.go
@@ -107,6 +107,11 @@ func TestSubscriptionAllFieldsWithBillingDayOfMonth(t *testing.T) {
 		BillingDayOfMonth:     &billingDayOfMonth,
 		NumberOfBillingCycles: &numberOfBillingCycles,
 		Price: NewDecimal(100, 2),
+		Descriptor: &Descriptor{
+			Name:  "Company Name*Product 1",
+			Phone: "0000000000",
+			URL:   "example.com",
+		},
 	})
 
 	t.Log("sub1", sub1)
@@ -131,6 +136,15 @@ func TestSubscriptionAllFieldsWithBillingDayOfMonth(t *testing.T) {
 	}
 	if x := sub1.TrialPeriod; x == nil || !x.Valid || x.Bool {
 		t.Fatalf("got trial period %#v, want false", x)
+	}
+	if x := sub1.Descriptor.Name; x != "Company Name*Product 1" {
+		t.Fatalf("got descriptor name %#v, want Company Name*Product 1", x)
+	}
+	if x := sub1.Descriptor.Phone; x != "0000000000" {
+		t.Fatalf("got descriptor phone %#v, want 0000000000", x)
+	}
+	if x := sub1.Descriptor.URL; x != "example.com" {
+		t.Fatalf("got descriptor url %#v, want example.com", x)
 	}
 
 	// Update
@@ -199,6 +213,11 @@ func TestSubscriptionAllFieldsWithBillingDayOfMonthNeverExpires(t *testing.T) {
 		BillingDayOfMonth:  &billingDayOfMonth,
 		NeverExpires:       &neverExpires,
 		Price:              NewDecimal(100, 2),
+		Descriptor: &Descriptor{
+			Name:  "Company Name*Product 1",
+			Phone: "0000000000",
+			URL:   "example.com",
+		},
 	})
 
 	t.Log("sub1", sub1)
@@ -223,6 +242,15 @@ func TestSubscriptionAllFieldsWithBillingDayOfMonthNeverExpires(t *testing.T) {
 	}
 	if x := sub1.TrialPeriod; x == nil || !x.Valid || x.Bool {
 		t.Fatalf("got trial period %#v, want false", x)
+	}
+	if x := sub1.Descriptor.Name; x != "Company Name*Product 1" {
+		t.Fatalf("got descriptor name %#v, want Company Name*Product 1", x)
+	}
+	if x := sub1.Descriptor.Phone; x != "0000000000" {
+		t.Fatalf("got descriptor phone %#v, want 0000000000", x)
+	}
+	if x := sub1.Descriptor.URL; x != "example.com" {
+		t.Fatalf("got descriptor url %#v, want example.com", x)
 	}
 
 	// Update
@@ -291,6 +319,11 @@ func TestSubscriptionAllFieldsWithFirstBillingDate(t *testing.T) {
 		FirstBillingDate:      firstBillingDate,
 		NumberOfBillingCycles: &numberOfBillingCycles,
 		Price: NewDecimal(100, 2),
+		Descriptor: &Descriptor{
+			Name:  "Company Name*Product 1",
+			Phone: "0000000000",
+			URL:   "example.com",
+		},
 	})
 
 	t.Log("sub1", sub1)
@@ -318,6 +351,15 @@ func TestSubscriptionAllFieldsWithFirstBillingDate(t *testing.T) {
 	}
 	if x := sub1.TrialPeriod; x == nil || !x.Valid || x.Bool {
 		t.Fatalf("got trial period %#v, want false", x)
+	}
+	if x := sub1.Descriptor.Name; x != "Company Name*Product 1" {
+		t.Fatalf("got descriptor name %#v, want Company Name*Product 1", x)
+	}
+	if x := sub1.Descriptor.Phone; x != "0000000000" {
+		t.Fatalf("got descriptor phone %#v, want 0000000000", x)
+	}
+	if x := sub1.Descriptor.URL; x != "example.com" {
+		t.Fatalf("got descriptor url %#v, want example.com", x)
 	}
 
 	// Update
@@ -386,6 +428,11 @@ func TestSubscriptionAllFieldsWithFirstBillingDateNeverExpires(t *testing.T) {
 		FirstBillingDate:   firstBillingDate,
 		NeverExpires:       &neverExpires,
 		Price:              NewDecimal(100, 2),
+		Descriptor: &Descriptor{
+			Name:  "Company Name*Product 1",
+			Phone: "0000000000",
+			URL:   "example.com",
+		},
 	})
 
 	t.Log("sub1", sub1)
@@ -413,6 +460,15 @@ func TestSubscriptionAllFieldsWithFirstBillingDateNeverExpires(t *testing.T) {
 	}
 	if x := sub1.TrialPeriod; x == nil || !x.Valid || x.Bool {
 		t.Fatalf("got trial period %#v, want false", x)
+	}
+	if x := sub1.Descriptor.Name; x != "Company Name*Product 1" {
+		t.Fatalf("got descriptor name %#v, want Company Name*Product 1", x)
+	}
+	if x := sub1.Descriptor.Phone; x != "0000000000" {
+		t.Fatalf("got descriptor phone %#v, want 0000000000", x)
+	}
+	if x := sub1.Descriptor.URL; x != "example.com" {
+		t.Fatalf("got descriptor url %#v, want example.com", x)
 	}
 
 	// Update
@@ -484,6 +540,11 @@ func TestSubscriptionAllFieldsWithTrialPeriod(t *testing.T) {
 		TrialDurationUnit:     SubscriptionTrialDurationUnitDay,
 		NumberOfBillingCycles: &numberOfBillingCycles,
 		Price: NewDecimal(100, 2),
+		Descriptor: &Descriptor{
+			Name:  "Company Name*Product 1",
+			Phone: "0000000000",
+			URL:   "example.com",
+		},
 	})
 
 	t.Log("sub1", sub1)
@@ -517,6 +578,15 @@ func TestSubscriptionAllFieldsWithTrialPeriod(t *testing.T) {
 	}
 	if sub1.TrialDurationUnit != SubscriptionTrialDurationUnitDay {
 		t.Fatalf("got trial duration unit %#v, want day", sub1.TrialDurationUnit)
+	}
+	if x := sub1.Descriptor.Name; x != "Company Name*Product 1" {
+		t.Fatalf("got descriptor name %#v, want Company Name*Product 1", x)
+	}
+	if x := sub1.Descriptor.Phone; x != "0000000000" {
+		t.Fatalf("got descriptor phone %#v, want 0000000000", x)
+	}
+	if x := sub1.Descriptor.URL; x != "example.com" {
+		t.Fatalf("got descriptor url %#v, want example.com", x)
 	}
 
 	// Update
@@ -588,6 +658,11 @@ func TestSubscriptionAllFieldsWithTrialPeriodNeverExpires(t *testing.T) {
 		TrialDurationUnit:  SubscriptionTrialDurationUnitDay,
 		NeverExpires:       &neverExpires,
 		Price:              NewDecimal(100, 2),
+		Descriptor: &Descriptor{
+			Name:  "Company Name*Product 1",
+			Phone: "0000000000",
+			URL:   "example.com",
+		},
 	})
 
 	t.Log("sub1", sub1)
@@ -621,6 +696,15 @@ func TestSubscriptionAllFieldsWithTrialPeriodNeverExpires(t *testing.T) {
 	}
 	if sub1.TrialDurationUnit != SubscriptionTrialDurationUnitDay {
 		t.Fatalf("got trial duration unit %#v, want day", sub1.TrialDurationUnit)
+	}
+	if x := sub1.Descriptor.Name; x != "Company Name*Product 1" {
+		t.Fatalf("got descriptor name %#v, want Company Name*Product 1", x)
+	}
+	if x := sub1.Descriptor.Phone; x != "0000000000" {
+		t.Fatalf("got descriptor phone %#v, want 0000000000", x)
+	}
+	if x := sub1.Descriptor.URL; x != "example.com" {
+		t.Fatalf("got descriptor url %#v, want example.com", x)
 	}
 
 	// Update

--- a/transaction.go
+++ b/transaction.go
@@ -39,6 +39,7 @@ type Transaction struct {
 	PayPalDetails               *PayPalDetails       `xml:"paypal,omitempty"`
 	AdditionalProcessorResponse string               `xml:"additional-processor-response,omitempty"`
 	RiskData                    *RiskData            `xml:"risk-data,omitempty"`
+	Descriptor                  *Descriptor          `xml:"descriptor,omitempty"`
 }
 
 // TODO: not all transaction fields are implemented yet, here are the missing fields (add on demand)

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -169,6 +169,47 @@ func TestFindNonExistantTransaction(t *testing.T) {
 	}
 }
 
+// This test will fail unless you set up your Braintree sandbox account correctly. See TESTING.md for details.
+func TestTransactionDescriptorFields(t *testing.T) {
+	tx := &Transaction{
+		Type:               "sale",
+		Amount:             randomAmount(),
+		PaymentMethodNonce: FakeNonceTransactable,
+		Options: &TransactionOptions{
+			SubmitForSettlement: true,
+		},
+		Descriptor: &Descriptor{
+			Name:  "Company Name*Product 1",
+			Phone: "0000000000",
+			URL:   "example.com",
+		},
+	}
+
+	tx2, err := testGateway.Transaction().Create(tx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if tx2.Type != tx.Type {
+		t.Fatalf("expected Type to be equal, but %s was not %s", tx2.Type, tx.Type)
+	}
+	if tx2.Amount.Cmp(tx.Amount) != 0 {
+		t.Fatalf("expected Amount to be equal, but %s was not %s", tx2.Amount, tx.Amount)
+	}
+	if tx2.Status != "submitted_for_settlement" {
+		t.Fatalf("expected tx2.Status to be %s, but got %s", "submitted_for_settlement", tx2.Status)
+	}
+	if tx2.Descriptor.Name != "Company Name*Product 1" {
+		t.Fatalf("expected tx2.Descriptor.Name to be Company Name*Product 1, but got %s", tx2.Descriptor.Name)
+	}
+	if tx2.Descriptor.Phone != "0000000000" {
+		t.Fatalf("expected tx2.Descriptor.Phone to be 0000000000, but got %s", tx2.Descriptor.Phone)
+	}
+	if tx2.Descriptor.URL != "example.com" {
+		t.Fatalf("expected tx2.Descriptor.URL to be example.com, but got %s", tx2.Descriptor.URL)
+	}
+}
+
 func TestAllTransactionFields(t *testing.T) {
 	tx := &Transaction{
 		Type:    "sale",


### PR DESCRIPTION
What
===
Add descriptor to `Transaction` and `Subscriptions`.

Why
===
So that a merchant can set and see the dynamic descriptor if their
account supports it.

Notes
===
The expectations for descriptors on `Transaction`s are not included in
the `TestAllTransactionFields` test because they will only pass if the
sandbox account is configured for dynamic descriptors but are instead
separated into their own test with an explanation on that tests
dependency.

This change is a rewrite of the part of #94 that added descriptors and
a part of getting that PR's logic committed piece meal.