### PR TITLE
Add modifications (addons and discounts) to subscriptions

### DIFF
--- a/modification_request.go
+++ b/modification_request.go
@@ -1,0 +1,66 @@
+package braintree
+
+import (
+	"encoding/xml"
+)
+
+type ModificationRequest struct {
+	Amount                *Decimal `xml:"amount,omitempty"`
+	NumberOfBillingCycles int      `xml:"number-of-billing-cycles,omitempty"`
+	Quantity              int      `xml:"quantity,omitempty"`
+	NeverExpires          bool     `xml:"never-expires,omitempty"`
+}
+
+type AddModificationRequest struct {
+	ModificationRequest
+	InheritedFromID string `xml:"inherited-from-id,omitempty"`
+}
+
+type UpdateModificationRequest struct {
+	ModificationRequest
+	ExistingID string `xml:"existing-id,omitempty"`
+}
+
+type ModificationsRequest struct {
+	Add               []AddModificationRequest
+	Update            []UpdateModificationRequest
+	RemoveExistingIDs []string
+}
+
+func (m ModificationsRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	e.EncodeToken(start)
+	if len(m.Add) > 0 {
+		if err := m.marshalXMLModifications(e, "add", m.Add); err != nil {
+			return err
+		}
+	}
+	if len(m.Update) > 0 {
+		if err := m.marshalXMLModifications(e, "update", m.Update); err != nil {
+			return err
+		}
+	}
+	if len(m.RemoveExistingIDs) > 0 {
+		if err := m.marshalXMLModifications(e, "remove", m.RemoveExistingIDs); err != nil {
+			return err
+		}
+	}
+	e.EncodeToken(start.End())
+	return nil
+}
+
+func (m ModificationsRequest) marshalXMLModifications(e *xml.Encoder, name string, modifications interface{}) error {
+	attr := []xml.Attr{{Name: xml.Name{Local: "type"}, Value: "array"}}
+	start := xml.StartElement{Name: xml.Name{Local: name}, Attr: attr}
+
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+	if err := e.EncodeElement(modifications, xml.StartElement{Name: xml.Name{Local: "modification"}}); err != nil {
+		return err
+	}
+	if err := e.EncodeToken(start.End()); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/modification_request_test.go
+++ b/modification_request_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 func TestModificationsXMLEmpty(t *testing.T) {
+	t.Parallel()
+
 	m := ModificationsRequest{}
 	output, err := xml.MarshalIndent(m, "", "  ")
 	if err != nil {
@@ -18,6 +20,8 @@ func TestModificationsXMLEmpty(t *testing.T) {
 }
 
 func TestModificationsXMLMinimalFields(t *testing.T) {
+	t.Parallel()
+
 	m := ModificationsRequest{
 		Add: []AddModificationRequest{
 			{
@@ -72,6 +76,8 @@ func TestModificationsXMLMinimalFields(t *testing.T) {
 }
 
 func TestModificationsXMLAllFields(t *testing.T) {
+	t.Parallel()
+
 	m := ModificationsRequest{
 		Add: []AddModificationRequest{
 			{

--- a/modification_request_test.go
+++ b/modification_request_test.go
@@ -1,0 +1,166 @@
+package braintree
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+func TestModificationsXMLEmpty(t *testing.T) {
+	m := ModificationsRequest{}
+	output, err := xml.MarshalIndent(m, "", "  ")
+	if err != nil {
+		t.Fatalf("got error %#v", err)
+	}
+	expectedOutput := `<ModificationsRequest></ModificationsRequest>`
+	if string(output) != expectedOutput {
+		t.Fatalf("got xml %#v, want %#v", string(output), expectedOutput)
+	}
+}
+
+func TestModificationsXMLMinimalFields(t *testing.T) {
+	m := ModificationsRequest{
+		Add: []AddModificationRequest{
+			{
+				InheritedFromID: "1",
+			},
+			{
+				InheritedFromID: "2",
+			},
+		},
+		Update: []UpdateModificationRequest{
+			{
+				ExistingID: "3",
+			},
+			{
+				ExistingID: "4",
+			},
+		},
+		RemoveExistingIDs: []string{
+			"5",
+			"6",
+		},
+	}
+	output, err := xml.MarshalIndent(m, "", "  ")
+	if err != nil {
+		t.Fatalf("got error %#v", err)
+	}
+	expectedOutput := `<ModificationsRequest>
+  <add type="array">
+    <modification>
+      <inherited-from-id>1</inherited-from-id>
+    </modification>
+    <modification>
+      <inherited-from-id>2</inherited-from-id>
+    </modification>
+  </add>
+  <update type="array">
+    <modification>
+      <existing-id>3</existing-id>
+    </modification>
+    <modification>
+      <existing-id>4</existing-id>
+    </modification>
+  </update>
+  <remove type="array">
+    <modification>5</modification>
+    <modification>6</modification>
+  </remove>
+</ModificationsRequest>`
+	if string(output) != expectedOutput {
+		t.Fatalf("got xml %#v, want %#v", string(output), expectedOutput)
+	}
+}
+
+func TestModificationsXMLAllFields(t *testing.T) {
+	m := ModificationsRequest{
+		Add: []AddModificationRequest{
+			{
+				InheritedFromID: "1",
+				ModificationRequest: ModificationRequest{
+					Amount:                NewDecimal(100, 2),
+					NumberOfBillingCycles: 1,
+					Quantity:              1,
+					NeverExpires:          true,
+				},
+			},
+			{
+				InheritedFromID: "2",
+				ModificationRequest: ModificationRequest{
+					Amount:                NewDecimal(200, 2),
+					NumberOfBillingCycles: 2,
+					Quantity:              2,
+					NeverExpires:          true,
+				},
+			},
+		},
+		Update: []UpdateModificationRequest{
+			{
+				ExistingID: "3",
+				ModificationRequest: ModificationRequest{
+					Amount:                NewDecimal(300, 2),
+					NumberOfBillingCycles: 3,
+					Quantity:              3,
+					NeverExpires:          true,
+				},
+			},
+			{
+				ExistingID: "4",
+				ModificationRequest: ModificationRequest{
+					Amount:                NewDecimal(400, 2),
+					NumberOfBillingCycles: 4,
+					Quantity:              4,
+					NeverExpires:          true,
+				},
+			},
+		},
+		RemoveExistingIDs: []string{
+			"5",
+			"6",
+		},
+	}
+	output, err := xml.MarshalIndent(m, "", "  ")
+	if err != nil {
+		t.Fatalf("got error %#v", err)
+	}
+	expectedOutput := `<ModificationsRequest>
+  <add type="array">
+    <modification>
+      <amount>1.00</amount>
+      <number-of-billing-cycles>1</number-of-billing-cycles>
+      <quantity>1</quantity>
+      <never-expires>true</never-expires>
+      <inherited-from-id>1</inherited-from-id>
+    </modification>
+    <modification>
+      <amount>2.00</amount>
+      <number-of-billing-cycles>2</number-of-billing-cycles>
+      <quantity>2</quantity>
+      <never-expires>true</never-expires>
+      <inherited-from-id>2</inherited-from-id>
+    </modification>
+  </add>
+  <update type="array">
+    <modification>
+      <amount>3.00</amount>
+      <number-of-billing-cycles>3</number-of-billing-cycles>
+      <quantity>3</quantity>
+      <never-expires>true</never-expires>
+      <existing-id>3</existing-id>
+    </modification>
+    <modification>
+      <amount>4.00</amount>
+      <number-of-billing-cycles>4</number-of-billing-cycles>
+      <quantity>4</quantity>
+      <never-expires>true</never-expires>
+      <existing-id>4</existing-id>
+    </modification>
+  </update>
+  <remove type="array">
+    <modification>5</modification>
+    <modification>6</modification>
+  </remove>
+</ModificationsRequest>`
+	if string(output) != expectedOutput {
+		t.Fatalf("got xml %#v, want %#v", string(output), expectedOutput)
+	}
+}

--- a/subscription.go
+++ b/subscription.go
@@ -25,7 +25,6 @@ type Subscription struct {
 	BillingPeriodStartDate  string               `xml:"billing-period-start-date,omitempty"`
 	CurrentBillingCycle     string               `xml:"current-billing-cycle,omitempty"`
 	DaysPastDue             string               `xml:"days-past-due,omitempty"`
-	Discounts               []interface{}        `xml:"discounts,omitempty"`
 	FailureCount            string               `xml:"failure-count,omitempty"`
 	FirstBillingDate        string               `xml:"first-billing-date,omitempty"`
 	MerchantAccountId       string               `xml:"merchant-account-id,omitempty"`
@@ -45,27 +44,30 @@ type Subscription struct {
 	Transactions            *Transactions        `xml:"transactions,omitempty"`
 	Options                 *SubscriptionOptions `xml:"options,omitempty"`
 	Descriptor              *Descriptor          `xml:"descriptor,omitempty"`
-	// AddOns                  []interface{} `xml:"add-ons,omitempty"`
+	AddOns                  *AddOnList           `xml:"add-ons,omitempty"`
+	Discounts               *DiscountList        `xml:"discounts,omitempty"`
 }
 
 type SubscriptionRequest struct {
-	XMLName               string               `xml:"subscription"`
-	Id                    string               `xml:"id,omitempty"`
-	BillingDayOfMonth     *nullable.NullInt64  `xml:"billing-day-of-month,omitempty"`
-	FailureCount          string               `xml:"failure-count,omitempty"`
-	FirstBillingDate      string               `xml:"first-billing-date,omitempty"`
-	MerchantAccountId     string               `xml:"merchant-account-id,omitempty"`
-	NeverExpires          *nullable.NullBool   `xml:"never-expires,omitempty"`
-	NumberOfBillingCycles *nullable.NullInt64  `xml:"number-of-billing-cycles,omitempty"`
-	Options               *SubscriptionOptions `xml:"options,omitempty"`
-	PaymentMethodNonce    string               `xml:"paymentMethodNonce,omitempty"`
-	PaymentMethodToken    string               `xml:"paymentMethodToken,omitempty"`
-	PlanId                string               `xml:"planId,omitempty"`
-	Price                 *Decimal             `xml:"price,omitempty"`
-	TrialDuration         string               `xml:"trial-duration,omitempty"`
-	TrialDurationUnit     string               `xml:"trial-duration-unit,omitempty"`
-	TrialPeriod           *nullable.NullBool   `xml:"trial-period,omitempty"`
-	Descriptor            *Descriptor          `xml:"descriptor,omitempty"`
+	XMLName               string                `xml:"subscription"`
+	Id                    string                `xml:"id,omitempty"`
+	BillingDayOfMonth     *nullable.NullInt64   `xml:"billing-day-of-month,omitempty"`
+	FailureCount          string                `xml:"failure-count,omitempty"`
+	FirstBillingDate      string                `xml:"first-billing-date,omitempty"`
+	MerchantAccountId     string                `xml:"merchant-account-id,omitempty"`
+	NeverExpires          *nullable.NullBool    `xml:"never-expires,omitempty"`
+	NumberOfBillingCycles *nullable.NullInt64   `xml:"number-of-billing-cycles,omitempty"`
+	Options               *SubscriptionOptions  `xml:"options,omitempty"`
+	PaymentMethodNonce    string                `xml:"paymentMethodNonce,omitempty"`
+	PaymentMethodToken    string                `xml:"paymentMethodToken,omitempty"`
+	PlanId                string                `xml:"planId,omitempty"`
+	Price                 *Decimal              `xml:"price,omitempty"`
+	TrialDuration         string                `xml:"trial-duration,omitempty"`
+	TrialDurationUnit     string                `xml:"trial-duration-unit,omitempty"`
+	TrialPeriod           *nullable.NullBool    `xml:"trial-period,omitempty"`
+	Descriptor            *Descriptor           `xml:"descriptor,omitempty"`
+	AddOns                *ModificationsRequest `xml:"add-ons,omitempty"`
+	Discounts             *ModificationsRequest `xml:"discounts,omitempty"`
 }
 
 type Subscriptions struct {


### PR DESCRIPTION
What
===
Add modifications (addons and discounts) to subscriptions.

Why
===
So that a merchant can add or change addons and discounts attached to subscriptions.

Notes
===
This PR is a continuation of the work discussed in #94 to break that PR up.