### PR TITLE
Adds date range field support - settled-at, dispute-date, etc. (cont.)

### DIFF
--- a/search.go
+++ b/search.go
@@ -42,9 +42,12 @@ type RangeDateField struct {
 }
 
 func (d RangeDateField) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	start = start.Copy()
+	start.Name = d.XMLName
+
 	var err error
 	format := "01/02/2006 15:04:05"
-	err = e.EncodeToken(xml.StartElement{Name: d.XMLName})
+	err = e.EncodeToken(start)
 	if err != nil {
 		return err
 	}
@@ -68,7 +71,7 @@ func (d RangeDateField) MarshalXML(e *xml.Encoder, start xml.StartElement) error
 		}
 	}
 
-	err = e.EncodeToken(xml.EndElement{Name: d.XMLName})
+	err = e.EncodeToken(start.End())
 	return err
 }
 

--- a/search.go
+++ b/search.go
@@ -76,6 +76,7 @@ func (d RangeDateField) marshalXMLCriterion(e *xml.Encoder, name string, value t
 	}
 	const format = "01/02/2006 15:04:05"
 	start := xml.StartElement{Name: xml.Name{Local: name}}
+	start.Attr = []xml.Attr{{Name: xml.Name{Local: "type"}, Value: "datetime"}}
 	return e.EncodeElement(value.Format(format), start)
 }
 

--- a/search.go
+++ b/search.go
@@ -74,10 +74,10 @@ func (d TimeField) marshalXMLCriterion(e *xml.Encoder, name string, value time.T
 	if value.IsZero() {
 		return nil
 	}
-	const format = "01/02/2006 15:04:05"
+	const format = "2006-01-02T15:04:05Z"
 	start := xml.StartElement{Name: xml.Name{Local: name}}
 	start.Attr = []xml.Attr{{Name: xml.Name{Local: "type"}, Value: "datetime"}}
-	return e.EncodeElement(value.Format(format), start)
+	return e.EncodeElement(value.UTC().Format(format), start)
 }
 
 type MultiField struct {

--- a/search.go
+++ b/search.go
@@ -36,9 +36,9 @@ type RangeField struct {
 
 type RangeDateField struct {
 	XMLName xml.Name
-	Is      time.Time `xml:"is,omitempty"`
-	Min     time.Time `xml:"min,omitempty"`
-	Max     time.Time `xml:"max,omitempty"`
+	Is      time.Time
+	Min     time.Time
+	Max     time.Time
 }
 
 func (d RangeDateField) MarshalXML(e *xml.Encoder, start xml.StartElement) error {

--- a/search.go
+++ b/search.go
@@ -46,33 +46,37 @@ func (d RangeDateField) MarshalXML(e *xml.Encoder, start xml.StartElement) error
 	start.Name = d.XMLName
 
 	var err error
-	format := "01/02/2006 15:04:05"
 	err = e.EncodeToken(start)
 	if err != nil {
 		return err
 	}
 
-	if !d.Is.IsZero() {
-		err = e.EncodeElement(d.Is.Format(format), xml.StartElement{Name: xml.Name{Local: "is"}})
-		if err != nil {
-			return err
-		}
+	err = d.marshalXMLCriterion(e, "is", d.Is)
+	if err != nil {
+		return err
 	}
-	if !d.Min.IsZero() {
-		err = e.EncodeElement(d.Min.Format(format), xml.StartElement{Name: xml.Name{Local: "min"}})
-		if err != nil {
-			return err
-		}
+
+	err = d.marshalXMLCriterion(e, "min", d.Min)
+	if err != nil {
+		return err
 	}
-	if !d.Max.IsZero() {
-		err = e.EncodeElement(d.Max.Format(format), xml.StartElement{Name: xml.Name{Local: "max"}})
-		if err != nil {
-			return err
-		}
+
+	err = d.marshalXMLCriterion(e, "max", d.Max)
+	if err != nil {
+		return err
 	}
 
 	err = e.EncodeToken(start.End())
 	return err
+}
+
+func (d RangeDateField) marshalXMLCriterion(e *xml.Encoder, name string, value time.Time) error {
+	if value.IsZero() {
+		return nil
+	}
+	const format = "01/02/2006 15:04:05"
+	start := xml.StartElement{Name: xml.Name{Local: name}}
+	return e.EncodeElement(value.Format(format), start)
 }
 
 type MultiField struct {

--- a/search.go
+++ b/search.go
@@ -34,14 +34,14 @@ type RangeField struct {
 	Max     float64 `xml:"max,omitempty"`
 }
 
-type RangeDateField struct {
+type TimeField struct {
 	XMLName xml.Name
 	Is      time.Time
 	Min     time.Time
 	Max     time.Time
 }
 
-func (d RangeDateField) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (d TimeField) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	start = start.Copy()
 	start.Name = d.XMLName
 
@@ -70,7 +70,7 @@ func (d RangeDateField) MarshalXML(e *xml.Encoder, start xml.StartElement) error
 	return err
 }
 
-func (d RangeDateField) marshalXMLCriterion(e *xml.Encoder, name string, value time.Time) error {
+func (d TimeField) marshalXMLCriterion(e *xml.Encoder, name string, value time.Time) error {
 	if value.IsZero() {
 		return nil
 	}
@@ -98,8 +98,8 @@ func (s *SearchQuery) AddRangeField(field string) *RangeField {
 	return f
 }
 
-func (s *SearchQuery) AddRangeDateField(field string) *RangeDateField {
-	f := &RangeDateField{XMLName: xml.Name{Local: field}}
+func (s *SearchQuery) AddTimeField(field string) *TimeField {
+	f := &TimeField{XMLName: xml.Name{Local: field}}
 	s.Fields = append(s.Fields, f)
 	return f
 }

--- a/search_test.go
+++ b/search_test.go
@@ -23,38 +23,38 @@ func TestSearchXMLEncode(t *testing.T) {
 
 	startDate := time.Date(2016, time.September, 11, 0, 0, 0, 0, time.UTC)
 	endDate := time.Date(2016, time.September, 11, 23, 59, 59, 0, time.UTC)
-	f3 := s.AddRangeDateField("settled-at")
+	f3 := s.AddTimeField("settled-at")
 	f3.Min = startDate
 	f3.Max = endDate
 
-	f4 := s.AddRangeDateField("created-at")
+	f4 := s.AddTimeField("created-at")
 	f4.Min = startDate
 
-	f5 := s.AddRangeDateField("authorization-expired-at")
+	f5 := s.AddTimeField("authorization-expired-at")
 	f5.Min = startDate
 
-	f6 := s.AddRangeDateField("authorized-at")
+	f6 := s.AddTimeField("authorized-at")
 	f6.Min = startDate
 
-	f7 := s.AddRangeDateField("failed-at")
+	f7 := s.AddTimeField("failed-at")
 	f7.Min = startDate
 
-	f8 := s.AddRangeDateField("gateway-rejected-at")
+	f8 := s.AddTimeField("gateway-rejected-at")
 	f8.Min = startDate
 
-	f9 := s.AddRangeDateField("processor-declined-at")
+	f9 := s.AddTimeField("processor-declined-at")
 	f9.Min = startDate
 
-	f10 := s.AddRangeDateField("submitted-for-settlement-at")
+	f10 := s.AddTimeField("submitted-for-settlement-at")
 	f10.Min = startDate
 
-	f11 := s.AddRangeDateField("voided-at")
+	f11 := s.AddTimeField("voided-at")
 	f11.Min = startDate
 
-	f12 := s.AddRangeDateField("disbursement-date")
+	f12 := s.AddTimeField("disbursement-date")
 	f12.Min = startDate
 
-	f13 := s.AddRangeDateField("dispute-date")
+	f13 := s.AddTimeField("dispute-date")
 	f13.Min = startDate
 
 	f14 := s.AddMultiField("status")

--- a/search_test.go
+++ b/search_test.go
@@ -84,38 +84,38 @@ func TestSearchXMLEncode(t *testing.T) {
     <max>20.01</max>
   </amount>
   <settled-at>
-    <min>09/11/2016 00:00:00</min>
-    <max>09/11/2016 23:59:59</max>
+    <min type="datetime">09/11/2016 00:00:00</min>
+    <max type="datetime">09/11/2016 23:59:59</max>
   </settled-at>
   <created-at>
-    <min>09/11/2016 00:00:00</min>
+    <min type="datetime">09/11/2016 00:00:00</min>
   </created-at>
   <authorization-expired-at>
-    <min>09/11/2016 00:00:00</min>
+    <min type="datetime">09/11/2016 00:00:00</min>
   </authorization-expired-at>
   <authorized-at>
-    <min>09/11/2016 00:00:00</min>
+    <min type="datetime">09/11/2016 00:00:00</min>
   </authorized-at>
   <failed-at>
-    <min>09/11/2016 00:00:00</min>
+    <min type="datetime">09/11/2016 00:00:00</min>
   </failed-at>
   <gateway-rejected-at>
-    <min>09/11/2016 00:00:00</min>
+    <min type="datetime">09/11/2016 00:00:00</min>
   </gateway-rejected-at>
   <processor-declined-at>
-    <min>09/11/2016 00:00:00</min>
+    <min type="datetime">09/11/2016 00:00:00</min>
   </processor-declined-at>
   <submitted-for-settlement-at>
-    <min>09/11/2016 00:00:00</min>
+    <min type="datetime">09/11/2016 00:00:00</min>
   </submitted-for-settlement-at>
   <voided-at>
-    <min>09/11/2016 00:00:00</min>
+    <min type="datetime">09/11/2016 00:00:00</min>
   </voided-at>
   <disbursement-date>
-    <min>09/11/2016 00:00:00</min>
+    <min type="datetime">09/11/2016 00:00:00</min>
   </disbursement-date>
   <dispute-date>
-    <min>09/11/2016 00:00:00</min>
+    <min type="datetime">09/11/2016 00:00:00</min>
   </dispute-date>
   <status type="array">
     <item>authorized</item>

--- a/search_test.go
+++ b/search_test.go
@@ -125,7 +125,7 @@ func TestSearchXMLEncode(t *testing.T) {
 </search>`
 
 	if xmls != expect {
-		t.Fatal(expect)
+		t.Fatalf("got %#v, want %#v", xmls, expect)
 	}
 }
 

--- a/search_test.go
+++ b/search_test.go
@@ -84,38 +84,38 @@ func TestSearchXMLEncode(t *testing.T) {
     <max>20.01</max>
   </amount>
   <settled-at>
-    <min type="datetime">09/11/2016 00:00:00</min>
-    <max type="datetime">09/11/2016 23:59:59</max>
+    <min type="datetime">2016-09-11T00:00:00Z</min>
+    <max type="datetime">2016-09-11T23:59:59Z</max>
   </settled-at>
   <created-at>
-    <min type="datetime">09/11/2016 00:00:00</min>
+    <min type="datetime">2016-09-11T00:00:00Z</min>
   </created-at>
   <authorization-expired-at>
-    <min type="datetime">09/11/2016 00:00:00</min>
+    <min type="datetime">2016-09-11T00:00:00Z</min>
   </authorization-expired-at>
   <authorized-at>
-    <min type="datetime">09/11/2016 00:00:00</min>
+    <min type="datetime">2016-09-11T00:00:00Z</min>
   </authorized-at>
   <failed-at>
-    <min type="datetime">09/11/2016 00:00:00</min>
+    <min type="datetime">2016-09-11T00:00:00Z</min>
   </failed-at>
   <gateway-rejected-at>
-    <min type="datetime">09/11/2016 00:00:00</min>
+    <min type="datetime">2016-09-11T00:00:00Z</min>
   </gateway-rejected-at>
   <processor-declined-at>
-    <min type="datetime">09/11/2016 00:00:00</min>
+    <min type="datetime">2016-09-11T00:00:00Z</min>
   </processor-declined-at>
   <submitted-for-settlement-at>
-    <min type="datetime">09/11/2016 00:00:00</min>
+    <min type="datetime">2016-09-11T00:00:00Z</min>
   </submitted-for-settlement-at>
   <voided-at>
-    <min type="datetime">09/11/2016 00:00:00</min>
+    <min type="datetime">2016-09-11T00:00:00Z</min>
   </voided-at>
   <disbursement-date>
-    <min type="datetime">09/11/2016 00:00:00</min>
+    <min type="datetime">2016-09-11T00:00:00Z</min>
   </disbursement-date>
   <dispute-date>
-    <min type="datetime">09/11/2016 00:00:00</min>
+    <min type="datetime">2016-09-11T00:00:00Z</min>
   </dispute-date>
   <status type="array">
     <item>authorized</item>

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -145,7 +145,7 @@ func TestTransactionSearchTime(t *testing.T) {
 		query := new(SearchQuery)
 		f1 := query.AddTextField("customer-first-name")
 		f1.Is = name0
-		f2 := query.AddRangeDateField("created-at")
+		f2 := query.AddTimeField("created-at")
 		f2.Max = time.Now()
 
 		result, err := txg.Search(query)
@@ -168,7 +168,7 @@ func TestTransactionSearchTime(t *testing.T) {
 		query := new(SearchQuery)
 		f1 := query.AddTextField("customer-first-name")
 		f1.Is = name0
-		f2 := query.AddRangeDateField("created-at")
+		f2 := query.AddTimeField("created-at")
 		f2.Max = time.Now().Add(-time.Hour)
 
 		result, err := txg.Search(query)

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -3,6 +3,7 @@ package braintree
 import (
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/lionelbarrow/braintree-go/testhelpers"
 )
@@ -108,6 +109,76 @@ func TestTransactionSearch(t *testing.T) {
 	if x := tx.Customer.FirstName; x != name0 {
 		t.Log(name0)
 		t.Fatal(x)
+	}
+}
+
+func TestTransactionSearchTime(t *testing.T) {
+	txg := testGateway.Transaction()
+	createTx := func(amount *Decimal, customerName string) error {
+		_, err := txg.Create(&Transaction{
+			Type:   "sale",
+			Amount: amount,
+			Customer: &Customer{
+				FirstName: customerName,
+			},
+			CreditCard: &CreditCard{
+				Number:         testCreditCards["visa"].Number,
+				ExpirationDate: "05/14",
+			},
+		})
+		return err
+	}
+
+	unique := testhelpers.RandomString()
+
+	name0 := "Erik-" + unique
+	if err := createTx(randomAmount(), name0); err != nil {
+		t.Fatal(err)
+	}
+
+	name1 := "Lionel-" + unique
+	if err := createTx(randomAmount(), name1); err != nil {
+		t.Fatal(err)
+	}
+
+	{ // test: txn is returned if querying for created at before now
+		query := new(SearchQuery)
+		f1 := query.AddTextField("customer-first-name")
+		f1.Is = name0
+		f2 := query.AddRangeDateField("created-at")
+		f2.Max = time.Now()
+
+		result, err := txg.Search(query)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !result.TotalItems.Valid || result.TotalItems.Int64 != 1 {
+			t.Fatal(result.Transactions)
+		}
+
+		tx := result.Transactions[0]
+		if x := tx.Customer.FirstName; x != name0 {
+			t.Log(name0)
+			t.Fatal(x)
+		}
+	}
+
+	{ // test: txn is not returned if querying for created at before 1 hour ago
+		query := new(SearchQuery)
+		f1 := query.AddTextField("customer-first-name")
+		f1.Is = name0
+		f2 := query.AddRangeDateField("created-at")
+		f2.Max = time.Now().Add(-time.Hour)
+
+		result, err := txg.Search(query)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !result.TotalItems.Valid || result.TotalItems.Int64 != 0 {
+			t.Fatal(result.Transactions)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR takes the changes proposed in #83 and makes some changes to that proposal that I think are needed or beneficial for it to be merged. If this PR is merged it will automatically close and merge #83. 

Main changes to call out:

* The field is named TimeRange to exactly match the Go type that is being searched with.
* Added an integration test.
* Corrected the time format that was being marshaled to be `YYYY-MM-DDTHH:mm:ssZ`.
* A few other less critical changes to the xml marshaling logic.

@rkulla: for putting the functionality together 👏 .