### PR TITLE
Restructure environments for easy overriding

### DIFF
--- a/braintree.go
+++ b/braintree.go
@@ -8,27 +8,7 @@ import (
 	"net/http"
 )
 
-type Environment string
-
-const (
-	Development Environment = "development"
-	Sandbox     Environment = "sandbox"
-	Production  Environment = "production"
-
-	LibraryVersion = "0.9.0"
-)
-
-func (e Environment) BaseURL() string {
-	switch e {
-	case Development:
-		return "http://localhost:3000"
-	case Sandbox:
-		return "https://sandbox.braintreegateway.com"
-	case Production:
-		return "https://www.braintreegateway.com"
-	}
-	panic(`invalid environment "` + e + `"`)
-}
+const LibraryVersion = "0.9.0"
 
 type ApiVersion int
 
@@ -66,7 +46,7 @@ type Braintree struct {
 }
 
 func (g *Braintree) MerchantURL() string {
-	return g.Environment.BaseURL() + "/merchants/" + g.MerchantId
+	return g.Environment.BaseURL + "/merchants/" + g.MerchantId
 }
 
 func (g *Braintree) execute(method, path string, xmlObj interface{}) (*Response, error) {

--- a/braintree.go
+++ b/braintree.go
@@ -46,7 +46,7 @@ type Braintree struct {
 }
 
 func (g *Braintree) MerchantURL() string {
-	return g.Environment.BaseURL + "/merchants/" + g.MerchantId
+	return g.Environment.BaseURL() + "/merchants/" + g.MerchantId
 }
 
 func (g *Braintree) execute(method, path string, xmlObj interface{}) (*Response, error) {

--- a/environment.go
+++ b/environment.go
@@ -1,15 +1,19 @@
 package braintree
 
 type Environment struct {
-	GatewayBaseURL string
+	baseURL string
+}
+
+func NewEnvironment(baseURL string) Environment {
+	return Environment{baseURL: baseURL}
 }
 
 func (e Environment) BaseURL() string {
-	return e.GatewayBaseURL
+	return e.baseURL
 }
 
 var (
-	Development = Environment{GatewayBaseURL: "http://localhost:3000"}
-	Sandbox     = Environment{GatewayBaseURL: "https://sandbox.braintreegateway.com"}
-	Production  = Environment{GatewayBaseURL: "https://www.braintreegateway.com"}
+	Development = NewEnvironment("http://localhost:3000")
+	Sandbox     = NewEnvironment("https://sandbox.braintreegateway.com")
+	Production  = NewEnvironment("https://www.braintreegateway.com")
 )

--- a/environment.go
+++ b/environment.go
@@ -1,0 +1,11 @@
+package braintree
+
+type Environment struct {
+	BaseURL string
+}
+
+var (
+	Development = Environment{BaseURL: "http://localhost:3000"}
+	Sandbox     = Environment{BaseURL: "https://sandbox.braintreegateway.com"}
+	Production  = Environment{BaseURL: "https://www.braintreegateway.com"}
+)

--- a/environment.go
+++ b/environment.go
@@ -1,11 +1,15 @@
 package braintree
 
 type Environment struct {
-	BaseURL string
+	GatewayBaseURL string
+}
+
+func (e Environment) BaseURL() string {
+	return e.GatewayBaseURL
 }
 
 var (
-	Development = Environment{BaseURL: "http://localhost:3000"}
-	Sandbox     = Environment{BaseURL: "https://sandbox.braintreegateway.com"}
-	Production  = Environment{BaseURL: "https://www.braintreegateway.com"}
+	Development = Environment{GatewayBaseURL: "http://localhost:3000"}
+	Sandbox     = Environment{GatewayBaseURL: "https://sandbox.braintreegateway.com"}
+	Production  = Environment{GatewayBaseURL: "https://www.braintreegateway.com"}
 )

--- a/environment_test.go
+++ b/environment_test.go
@@ -13,7 +13,7 @@ func TestEnvironmentBaseURL(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual := test.Environment.BaseURL()
+		actual := test.Environment.BaseURL
 		if actual != test.WantedBaseURL {
 			t.Fatalf("%#v.BaseURL() = %#v, want %#v", test.Environment, actual, test.WantedBaseURL)
 		}

--- a/environment_test.go
+++ b/environment_test.go
@@ -1,0 +1,21 @@
+package braintree
+
+import "testing"
+
+func TestEnvironmentBaseURL(t *testing.T) {
+	tests := []struct {
+		Environment   Environment
+		WantedBaseURL string
+	}{
+		{Development, "http://localhost:3000"},
+		{Sandbox, "https://sandbox.braintreegateway.com"},
+		{Production, "https://www.braintreegateway.com"},
+	}
+
+	for _, test := range tests {
+		actual := test.Environment.BaseURL()
+		if actual != test.WantedBaseURL {
+			t.Fatalf("%#v.BaseURL() = %#v, want %#v", test.Environment, actual, test.WantedBaseURL)
+		}
+	}
+}

--- a/environment_test.go
+++ b/environment_test.go
@@ -13,7 +13,7 @@ func TestEnvironmentBaseURL(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual := test.Environment.BaseURL
+		actual := test.Environment.BaseURL()
 		if actual != test.WantedBaseURL {
 			t.Fatalf("%#v.BaseURL() = %#v, want %#v", test.Environment, actual, test.WantedBaseURL)
 		}


### PR DESCRIPTION
What
===
Change `Environment` to be a `struct` containing `BaseURL` instead of it
being a type with underlying type string and a `BaseURL()` method.

Why
===
The `BaseURL()` function only returns hardcoded URLs and cannot
be overriden. This prevents a developer using the library from changing
the BaseURL. Interest in doing this was expressed in PR #56.

Using an exported struct with exported fields makes it easy for a
developer to construct their own environment. The use of a struct also
lets us expand it with other parameters if needed without breaking
existing uses, which is important as `Environment` is part of the
exported interface of the package.

@cjrd @lionelbarrow: Let me know if this doesn't meet the end you 
were trying to get to in #56. Otherwise this should close #56.