### PR TITLE
Add custom fields to transactions and customers

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -1,20 +1,24 @@
 package braintree
 
-import "github.com/lionelbarrow/braintree-go/nullable"
+import (
+	"github.com/lionelbarrow/braintree-go/customfields"
+	"github.com/lionelbarrow/braintree-go/nullable"
+)
 
 type Customer struct {
-	XMLName        string          `xml:"customer"`
-	Id             string          `xml:"id,omitempty"`
-	FirstName      string          `xml:"first-name,omitempty"`
-	LastName       string          `xml:"last-name,omitempty"`
-	Company        string          `xml:"company,omitempty"`
-	Email          string          `xml:"email,omitempty"`
-	Phone          string          `xml:"phone,omitempty"`
-	Fax            string          `xml:"fax,omitempty"`
-	Website        string          `xml:"website,omitempty"`
-	CreditCard     *CreditCard     `xml:"credit-card,omitempty"`
-	CreditCards    *CreditCards    `xml:"credit-cards,omitempty"`
-	PayPalAccounts *PayPalAccounts `xml:"paypal-accounts,omitempty"`
+	XMLName        string                    `xml:"customer"`
+	Id             string                    `xml:"id,omitempty"`
+	FirstName      string                    `xml:"first-name,omitempty"`
+	LastName       string                    `xml:"last-name,omitempty"`
+	Company        string                    `xml:"company,omitempty"`
+	Email          string                    `xml:"email,omitempty"`
+	Phone          string                    `xml:"phone,omitempty"`
+	Fax            string                    `xml:"fax,omitempty"`
+	Website        string                    `xml:"website,omitempty"`
+	CustomFields   customfields.CustomFields `xml:"custom-fields,omitempty"`
+	CreditCard     *CreditCard               `xml:"credit-card,omitempty"`
+	CreditCards    *CreditCards              `xml:"credit-cards,omitempty"`
+	PayPalAccounts *PayPalAccounts           `xml:"paypal-accounts,omitempty"`
 }
 
 // PaymentMethods returns a slice of all PaymentMethods this customer has

--- a/customer_integration_test.go
+++ b/customer_integration_test.go
@@ -118,6 +118,36 @@ func TestCustomer(t *testing.T) {
 	}
 }
 
+func TestCustomerWithCustomFields(t *testing.T) {
+	t.Parallel()
+
+	customFields := map[string]string{
+		"custom_field_1": "custom value",
+	}
+
+	c := &Customer{
+		CustomFields: customFields,
+	}
+
+	customer, err := testGateway.Customer().Create(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if x := map[string]string(customer.CustomFields); !reflect.DeepEqual(x, customFields) {
+		t.Fatalf("Returned custom fields doesn't match input, got %q, want %q", x, customFields)
+	}
+
+	customer, err = testGateway.Customer().Find(customer.Id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if x := map[string]string(customer.CustomFields); !reflect.DeepEqual(x, customFields) {
+		t.Fatalf("Returned custom fields doesn't match input, got %q, want %q", x, customFields)
+	}
+}
+
 func TestCustomerPayPalAccount(t *testing.T) {
 	t.Parallel()
 

--- a/customfields/custom_fields.go
+++ b/customfields/custom_fields.go
@@ -1,0 +1,60 @@
+package customfields
+
+import (
+	"encoding/xml"
+	"io"
+	"strings"
+)
+
+// CustomFields is a string to string map of custom field names to values.
+// Ref: https://articles.braintreepayments.com/control-panel/custom-fields
+type CustomFields map[string]string
+
+type xmlField struct {
+	XMLName xml.Name
+	Value   string `xml:",chardata"`
+}
+
+var nameMarshalReplacer = strings.NewReplacer("_", "-")
+var nameUnmarshalReplacer = strings.NewReplacer("-", "_")
+
+// MarshalXML encodes the map of custom fields names to values with the name as an xml tag and the value as it's contents. Tag names have underscores replaced with hyphens, as required by the Braintree API.
+func (c CustomFields) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if len(c) == 0 {
+		return nil
+	}
+
+	err := e.EncodeToken(start)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range c {
+		tag := nameMarshalReplacer.Replace(k)
+		e.Encode(xmlField{
+			XMLName: xml.Name{Local: tag},
+			Value:   v,
+		})
+	}
+
+	return e.EncodeToken(start.End())
+}
+
+// UnmarshalXML decodes the tags within into a map of custom fields names to values with the xml tag is the name and the contents is it's value. Tag names have hyphens replaced with underscores.
+func (c *CustomFields) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	*c = CustomFields{}
+	for {
+		var cf xmlField
+
+		err := d.Decode(&cf)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		name := nameUnmarshalReplacer.Replace(cf.XMLName.Local)
+		(*c)[name] = cf.Value
+	}
+	return nil
+}

--- a/customfields/custom_fields.go
+++ b/customfields/custom_fields.go
@@ -18,7 +18,9 @@ type xmlField struct {
 var nameMarshalReplacer = strings.NewReplacer("_", "-")
 var nameUnmarshalReplacer = strings.NewReplacer("-", "_")
 
-// MarshalXML encodes the map of custom fields names to values with the name as an xml tag and the value as it's contents. Tag names have underscores replaced with hyphens, as required by the Braintree API.
+// MarshalXML encodes the map of custom fields names to values with the name as
+// an xml tag and the value as it's contents. Tag names have underscores
+// replaced with hyphens, as required by the Braintree API.
 func (c CustomFields) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	if len(c) == 0 {
 		return nil
@@ -40,7 +42,9 @@ func (c CustomFields) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return e.EncodeToken(start.End())
 }
 
-// UnmarshalXML decodes the tags within into a map of custom fields names to values with the xml tag is the name and the contents is it's value. Tag names have hyphens replaced with underscores.
+// UnmarshalXML decodes the tags within into a map of custom fields names to
+// values with the xml tag is the name and the contents is it's value. Tag
+// names have hyphens replaced with underscores.
 func (c *CustomFields) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	*c = CustomFields{}
 	for {

--- a/customfields/custom_fields_test.go
+++ b/customfields/custom_fields_test.go
@@ -1,0 +1,186 @@
+package customfields
+
+import (
+	"encoding/xml"
+	"reflect"
+	"testing"
+)
+
+func TestCustomFieldsMarshalXMLNil(t *testing.T) {
+	type object struct {
+		Field        string       `xml:"field,omitempty"`
+		CustomFields CustomFields `xml:"custom-fields"`
+	}
+	o := object{}
+
+	output, err := xml.Marshal(o)
+	if err != nil {
+		t.Fatalf("Error marshaling custom fields: %#v", err)
+	}
+	xml := string(output)
+
+	if xml != "<object></object>" {
+		t.Fatalf("Got %#v, wanted custom fields ommited", xml)
+	}
+}
+
+func TestCustomFieldsMarshalXMLEmpty(t *testing.T) {
+	type object struct {
+		Field        string       `xml:"field,omitempty"`
+		CustomFields CustomFields `xml:"custom-fields"`
+	}
+	o := object{CustomFields: CustomFields{}}
+
+	output, err := xml.Marshal(o)
+	if err != nil {
+		t.Fatalf("Error marshaling custom fields: %#v", err)
+	}
+	xml := string(output)
+
+	if xml != "<object></object>" {
+		t.Fatalf("Got %#v, wanted custom fields ommited", xml)
+	}
+}
+
+func TestCustomFieldsMarshalXML(t *testing.T) {
+	type object struct {
+		Field        string       `xml:"field"`
+		CustomFields CustomFields `xml:"custom-fields"`
+	}
+	o := object{
+		Field: "1.00",
+		CustomFields: CustomFields{
+			"custom_field_1": "Custom Value",
+		},
+	}
+	wantedXML := `<object>
+  <field>1.00</field>
+  <custom-fields>
+    <custom-field-1>Custom Value</custom-field-1>
+  </custom-fields>
+</object>`
+
+	output, err := xml.MarshalIndent(o, "", "  ")
+	if err != nil {
+		t.Fatalf("Error marshaling custom fields: %#v", err)
+	}
+	xml := string(output)
+
+	if xml != wantedXML {
+		t.Fatalf("Got XML %#v, wanted %#v", xml, wantedXML)
+	}
+}
+
+func TestCustomFieldsUnmarshalXMLNilEmpty(t *testing.T) {
+	type object struct {
+		Field        string       `xml:"field"`
+		CustomFields CustomFields `xml:"custom-fields"`
+	}
+
+	s := `<object>
+  <field>1.00</field>
+</object>`
+	wantedObject := object{
+		Field:        "1.00",
+		CustomFields: nil,
+	}
+
+	o := object{}
+	err := xml.Unmarshal([]byte(s), &o)
+	if err != nil {
+		t.Fatalf("Error marshaling: %#v", err)
+	}
+
+	if !reflect.DeepEqual(o, wantedObject) {
+		t.Fatalf("Got %#v, wanted %#v", o, wantedObject)
+	}
+}
+
+func TestCustomFieldsUnmarshalXMLEmpty(t *testing.T) {
+	type object struct {
+		Field        string       `xml:"field"`
+		CustomFields CustomFields `xml:"custom-fields"`
+	}
+
+	s := `<object>
+  <field>1.00</field>
+</object>`
+	wantedObject := object{
+		Field:        "1.00",
+		CustomFields: nil,
+	}
+
+	o := object{}
+	err := xml.Unmarshal([]byte(s), &o)
+	if err != nil {
+		t.Fatalf("Error marshaling: %#v", err)
+	}
+
+	if !reflect.DeepEqual(o, wantedObject) {
+		t.Fatalf("Got %#v, wanted %#v", o, wantedObject)
+	}
+}
+
+func TestCustomFieldsUnmarshalXMLNil(t *testing.T) {
+	type object struct {
+		Field        string       `xml:"field"`
+		CustomFields CustomFields `xml:"custom-fields"`
+	}
+
+	s := `<object>
+  <field>1.00</field>
+  <custom-fields>
+    <custom-field-1>Custom Value One</custom-field-1>
+    <custom-field-2>Custom Value Two</custom-field-2>
+  </custom-fields>
+</object>`
+	wantedObject := object{
+		Field: "1.00",
+		CustomFields: CustomFields{
+			"custom_field_1": "Custom Value One",
+			"custom_field_2": "Custom Value Two",
+		},
+	}
+
+	o := object{}
+	err := xml.Unmarshal([]byte(s), &o)
+	if err != nil {
+		t.Fatalf("Error marshaling: %#v", err)
+	}
+
+	if !reflect.DeepEqual(o, wantedObject) {
+		t.Fatalf("Got %#v, wanted %#v", o, wantedObject)
+	}
+}
+
+func TestCustomFieldsUnmarshalXML(t *testing.T) {
+	type object struct {
+		Field        string       `xml:"field"`
+		CustomFields CustomFields `xml:"custom-fields"`
+	}
+
+	s := `<object>
+  <field>1.00</field>
+  <custom-fields>
+    <custom-field-1>Custom Value One</custom-field-1>
+    <custom-field-2>Custom Value Two</custom-field-2>
+  </custom-fields>
+</object>`
+	wantedObject := object{
+		Field: "1.00",
+		CustomFields: CustomFields{
+			"custom_field_1": "Custom Value One",
+			"custom_field_2": "Custom Value Two",
+		},
+	}
+
+	o := object{CustomFields: CustomFields{}}
+	err := xml.Unmarshal([]byte(s), &o)
+	if err != nil {
+		t.Fatalf("Error marshaling: %#v", err)
+	}
+
+	if !reflect.DeepEqual(o, wantedObject) {
+		t.Fatalf("Got %#v, wanted %#v", o, wantedObject)
+	}
+}

--- a/transaction.go
+++ b/transaction.go
@@ -3,43 +3,45 @@ package braintree
 import (
 	"time"
 
+	"github.com/lionelbarrow/braintree-go/customfields"
 	"github.com/lionelbarrow/braintree-go/nullable"
 )
 
 type Transaction struct {
-	XMLName                     string               `xml:"transaction"`
-	Id                          string               `xml:"id,omitempty"`
-	CustomerID                  string               `xml:"customer-id,omitempty"`
-	Status                      string               `xml:"status,omitempty"`
-	Type                        string               `xml:"type,omitempty"`
-	Amount                      *Decimal             `xml:"amount"`
-	OrderId                     string               `xml:"order-id,omitempty"`
-	PaymentMethodToken          string               `xml:"payment-method-token,omitempty"`
-	PaymentMethodNonce          string               `xml:"payment-method-nonce,omitempty"`
-	MerchantAccountId           string               `xml:"merchant-account-id,omitempty"`
-	PlanId                      string               `xml:"plan-id,omitempty"`
-	CreditCard                  *CreditCard          `xml:"credit-card,omitempty"`
-	Customer                    *Customer            `xml:"customer,omitempty"`
-	BillingAddress              *Address             `xml:"billing,omitempty"`
-	ShippingAddress             *Address             `xml:"shipping,omitempty"`
-	DeviceData                  string               `xml:"device-data,omitempty"`
-	Options                     *TransactionOptions  `xml:"options,omitempty"`
-	ServiceFeeAmount            *Decimal             `xml:"service-fee-amount,attr,omitempty"`
-	CreatedAt                   *time.Time           `xml:"created-at,omitempty"`
-	UpdatedAt                   *time.Time           `xml:"updated-at,omitempty"`
-	DisbursementDetails         *DisbursementDetails `xml:"disbursement-details,omitempty"`
-	RefundId                    string               `xml:"refund-id,omitempty"`
-	RefundIds                   *[]string            `xml:"refund-ids>item,omitempty"`
-	RefundedTransactionId       *string              `xml:"refunded-transaction-id,omitempty"`
-	ProcessorResponseCode       int                  `xml:"processor-response-code,omitempty"`
-	ProcessorResponseText       string               `xml:"processor-response-text,omitempty"`
-	ProcessorAuthorizationCode  string               `xml:"processor-authorization-code,omitempty"`
-	SettlementBatchId           string               `xml:"settlement-batch-id,omitempty"`
-	PaymentInstrumentType       string               `xml:"payment-instrument-type,omitempty"`
-	PayPalDetails               *PayPalDetails       `xml:"paypal,omitempty"`
-	AdditionalProcessorResponse string               `xml:"additional-processor-response,omitempty"`
-	RiskData                    *RiskData            `xml:"risk-data,omitempty"`
-	Descriptor                  *Descriptor          `xml:"descriptor,omitempty"`
+	XMLName                     string                    `xml:"transaction"`
+	Id                          string                    `xml:"id,omitempty"`
+	CustomerID                  string                    `xml:"customer-id,omitempty"`
+	Status                      string                    `xml:"status,omitempty"`
+	Type                        string                    `xml:"type,omitempty"`
+	Amount                      *Decimal                  `xml:"amount"`
+	OrderId                     string                    `xml:"order-id,omitempty"`
+	PaymentMethodToken          string                    `xml:"payment-method-token,omitempty"`
+	PaymentMethodNonce          string                    `xml:"payment-method-nonce,omitempty"`
+	MerchantAccountId           string                    `xml:"merchant-account-id,omitempty"`
+	PlanId                      string                    `xml:"plan-id,omitempty"`
+	CreditCard                  *CreditCard               `xml:"credit-card,omitempty"`
+	Customer                    *Customer                 `xml:"customer,omitempty"`
+	BillingAddress              *Address                  `xml:"billing,omitempty"`
+	ShippingAddress             *Address                  `xml:"shipping,omitempty"`
+	DeviceData                  string                    `xml:"device-data,omitempty"`
+	Options                     *TransactionOptions       `xml:"options,omitempty"`
+	ServiceFeeAmount            *Decimal                  `xml:"service-fee-amount,attr,omitempty"`
+	CreatedAt                   *time.Time                `xml:"created-at,omitempty"`
+	UpdatedAt                   *time.Time                `xml:"updated-at,omitempty"`
+	DisbursementDetails         *DisbursementDetails      `xml:"disbursement-details,omitempty"`
+	RefundId                    string                    `xml:"refund-id,omitempty"`
+	RefundIds                   *[]string                 `xml:"refund-ids>item,omitempty"`
+	RefundedTransactionId       *string                   `xml:"refunded-transaction-id,omitempty"`
+	ProcessorResponseCode       int                       `xml:"processor-response-code,omitempty"`
+	ProcessorResponseText       string                    `xml:"processor-response-text,omitempty"`
+	ProcessorAuthorizationCode  string                    `xml:"processor-authorization-code,omitempty"`
+	SettlementBatchId           string                    `xml:"settlement-batch-id,omitempty"`
+	PaymentInstrumentType       string                    `xml:"payment-instrument-type,omitempty"`
+	PayPalDetails               *PayPalDetails            `xml:"paypal,omitempty"`
+	AdditionalProcessorResponse string                    `xml:"additional-processor-response,omitempty"`
+	RiskData                    *RiskData                 `xml:"risk-data,omitempty"`
+	Descriptor                  *Descriptor               `xml:"descriptor,omitempty"`
+	CustomFields                customfields.CustomFields `xml:"custom-fields,omitempty"`
 }
 
 // TODO: not all transaction fields are implemented yet, here are the missing fields (add on demand)

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -2,6 +2,7 @@ package braintree
 
 import (
 	"math/rand"
+	"reflect"
 	"testing"
 	"time"
 
@@ -690,5 +691,37 @@ func TestTransactionCreateSettleCheckCreditCardDetails(t *testing.T) {
 
 	if txn.Status != "settled" {
 		t.Fatal(txn.Status)
+	}
+}
+
+func TestTransactionCreateWithCustomFields(t *testing.T) {
+	t.Parallel()
+
+	customFields := map[string]string{
+		"custom_field_1": "custom value",
+	}
+
+	amount := NewDecimal(10000, 2)
+	txn, err := testGateway.Transaction().Create(&Transaction{
+		Type:               "sale",
+		Amount:             amount,
+		PaymentMethodNonce: FakeNonceTransactable,
+		CustomFields:       customFields,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if x := map[string]string(txn.CustomFields); !reflect.DeepEqual(x, customFields) {
+		t.Fatalf("Returned custom fields doesn't match input, got %q, want %q", x, customFields)
+	}
+
+	txn, err = testGateway.Transaction().Find(txn.Id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if x := map[string]string(txn.CustomFields); !reflect.DeepEqual(x, customFields) {
+		t.Fatalf("Returned custom fields doesn't match input, got %q, want %q", x, customFields)
 	}
 }


### PR DESCRIPTION
What
===
Add custom fields to transactions and customers.

Why
===
Requested in #42. Allows users of the package creating customers and
transactions to specify custom fields which are supported by the API.

Ref
===

 * [Braintree Docs on Custom Fields](https://articles.braintreepayments.com/control-panel/custom-fields)
 * [braintree/braintree_ruby](https://github.com/braintree/braintree_ruby) client library:
   * [xml/generator.rb](https://github.com/braintree/braintree_ruby/blob/48b5f13cd6c8213787f0a83fdbccdb71bf075273/lib/braintree/xml/generator.rb)
   * [xml/parser.rb](https://github.com/braintree/braintree_ruby/blob/48b5f13cd6c8213787f0a83fdbccdb71bf075273/lib/braintree/xml/parser.rb)