### PR TITLE
Change ProcessorResponseCode type to a custom int type (Option 2)

### DIFF
--- a/processor_response_code.go
+++ b/processor_response_code.go
@@ -1,0 +1,33 @@
+package braintree
+
+import "strconv"
+
+type ProcessorResponseCode int
+
+func (rc ProcessorResponseCode) Int() int {
+	return int(rc)
+}
+
+// UnmarshalText fills the response code with the integer value if the text contains one in string form. If the text is zero length, the response code's value is unchanged but unmarshaling is successful.
+func (rc *ProcessorResponseCode) UnmarshalText(text []byte) error {
+	if len(text) == 0 {
+		return nil
+	}
+
+	n, err := strconv.Atoi(string(text))
+	if err != nil {
+		return err
+	}
+
+	*rc = ProcessorResponseCode(n)
+
+	return nil
+}
+
+// MarshalText returns a string in bytes of the number, or nil in the case it is zero.
+func (rc ProcessorResponseCode) MarshalText() ([]byte, error) {
+	if rc == 0 {
+		return nil, nil
+	}
+	return []byte(strconv.Itoa(int(rc))), nil
+}

--- a/transaction.go
+++ b/transaction.go
@@ -32,7 +32,7 @@ type Transaction struct {
 	RefundId                    string                    `xml:"refund-id,omitempty"`
 	RefundIds                   *[]string                 `xml:"refund-ids>item,omitempty"`
 	RefundedTransactionId       *string                   `xml:"refunded-transaction-id,omitempty"`
-	ProcessorResponseCode       int                       `xml:"processor-response-code,omitempty"`
+	ProcessorResponseCode       ProcessorResponseCode     `xml:"processor-response-code,omitempty"`
 	ProcessorResponseText       string                    `xml:"processor-response-text,omitempty"`
 	ProcessorAuthorizationCode  string                    `xml:"processor-authorization-code,omitempty"`
 	SettlementBatchId           string                    `xml:"settlement-batch-id,omitempty"`


### PR DESCRIPTION
What
===
Added a type for the ProcessorResponseCode on Transaction that unmarshals itself and considers an empty XML tag as zero.

Why
===
In some situations, e.g. a gateway reject, the processor response code field will be an empty string. The processor response code field on transaction is an int, but the default xml decoder will error when unmarshaling an empty string into an int.

This bug was reported in #89, which suggested solving the problem by wrapping the value in `nullable.NullInt64` like we have for similar fields. I did this as a spike out of an alternative to #89. See the discussion in the comments on #89 for three ways we can solve this problem.