### PR TITLE
Change ProcessorResponseCode type to string (Option 3)

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -32,7 +32,7 @@ type Transaction struct {
 	RefundId                    string                    `xml:"refund-id,omitempty"`
 	RefundIds                   *[]string                 `xml:"refund-ids>item,omitempty"`
 	RefundedTransactionId       *string                   `xml:"refunded-transaction-id,omitempty"`
-	ProcessorResponseCode       int                       `xml:"processor-response-code,omitempty"`
+	ProcessorResponseCode       string                    `xml:"processor-response-code,omitempty"`
 	ProcessorResponseText       string                    `xml:"processor-response-text,omitempty"`
 	ProcessorAuthorizationCode  string                    `xml:"processor-authorization-code,omitempty"`
 	SettlementBatchId           string                    `xml:"settlement-batch-id,omitempty"`


### PR DESCRIPTION
What
===
Added a type for the ProcessorResponseCode on Transaction that
unmarshals itself and considers an empty XML tag as zero.

Why
===
In some situations, e.g. a gateway reject, the processor response code
field will be an empty string. The processor response code field on
transaction is an int, but the default xml decoder will error when
unmarshaling an empty string into an int.

This bug was reported in #89, which suggested solving the problem by
wrapping the value in nullable.NullInt64 like we have for similar
fields. I did this as a spike out of an alternative to #89. See the
discussion in the comments on #89 for three ways we can solve this
problem.