### PR TITLE
Tighten the depencencies of hmacer

### DIFF
--- a/hmac.go
+++ b/hmac.go
@@ -20,12 +20,13 @@ func (i SignatureError) Error() string {
 	return i.message
 }
 
-func newHmacer(bt *Braintree) hmacer {
-	return hmacer{bt}
+func newHmacer(publicKey, privateKey string) hmacer {
+	return hmacer{publicKey: publicKey, privateKey: privateKey}
 }
 
 type hmacer struct {
-	*Braintree
+	publicKey  string
+	privateKey string
 }
 
 func (h hmacer) verifySignature(signature, payload string) (bool, error) {
@@ -49,7 +50,7 @@ func (h hmacer) parseSignature(signatureKeyPair string) (string, error) {
 		return "", SignatureError{"Signature-key pair contains more than one |"}
 	}
 	publicKey := split[0]
-	if publicKey != h.Braintree.PublicKey {
+	if publicKey != h.publicKey {
 		return "", SignatureError{"Signature-key pair contains the wrong public key!"}
 	}
 	return split[1], nil
@@ -57,7 +58,7 @@ func (h hmacer) parseSignature(signatureKeyPair string) (string, error) {
 
 func (h hmacer) hmac(payload string) (string, error) {
 	s := sha1.New()
-	_, err := io.WriteString(s, h.PrivateKey)
+	_, err := io.WriteString(s, h.privateKey)
 	if err != nil {
 		return "", errors.New("Could not write private key to SHA1")
 	}

--- a/hmac_test.go
+++ b/hmac_test.go
@@ -7,10 +7,10 @@ import (
 func TestHmacerParseSignature(t *testing.T) {
 	t.Parallel()
 
-	hmacer := newHmacer(testGateway)
+	hmacer := newHmacer(testGateway.PublicKey, testGateway.PrivateKey)
 
 	// Happy path
-	realSignature, err := hmacer.parseSignature(testGateway.PublicKey + "|my_actual_signature")
+	realSignature, err := hmacer.parseSignature(hmacer.publicKey + "|my_actual_signature")
 	if err != nil {
 		t.Fatal(err)
 	} else if realSignature != "my_actual_signature" {
@@ -39,9 +39,8 @@ func TestHmacerParseSignature(t *testing.T) {
 func TestHmacerVerifySignature(t *testing.T) {
 	t.Parallel()
 
-	gateway := New(Sandbox, "my_merchant_id", "my_public_key", "my_private_key")
-	hmacer := newHmacer(gateway)
-	signatureKeyPair := gateway.PublicKey + "|fa654fa4fe5537934960c483dbb0ee575d64b6ad"
+	hmacer := newHmacer("my_public_key", "my_private_key")
+	signatureKeyPair := hmacer.publicKey + "|fa654fa4fe5537934960c483dbb0ee575d64b6ad"
 	payload := "my_random_value"
 
 	// Happy path

--- a/webhook_notification_gateway.go
+++ b/webhook_notification_gateway.go
@@ -10,7 +10,7 @@ type WebhookNotificationGateway struct {
 }
 
 func (w *WebhookNotificationGateway) Parse(signature, payload string) (*WebhookNotification, error) {
-	hmacer := newHmacer(w.Braintree)
+	hmacer := newHmacer(w.Braintree.PublicKey, w.Braintree.PrivateKey)
 	if verified, err := hmacer.verifySignature(signature, payload); err != nil {
 		return nil, err
 	} else if !verified {
@@ -31,10 +31,10 @@ func (w *WebhookNotificationGateway) Parse(signature, payload string) (*WebhookN
 }
 
 func (w *WebhookNotificationGateway) Verify(challenge string) (string, error) {
-	hmacer := newHmacer(w.Braintree)
+	hmacer := newHmacer(w.Braintree.PublicKey, w.Braintree.PrivateKey)
 	digest, err := hmacer.hmac(challenge)
 	if err != nil {
 		return ``, err
 	}
-	return hmacer.PublicKey + `|` + digest, nil
+	return hmacer.publicKey + `|` + digest, nil
 }

--- a/webhook_notification_test.go
+++ b/webhook_notification_test.go
@@ -9,7 +9,7 @@ func TestWebhookParseMerchantAccountAccepted(t *testing.T) {
 	t.Parallel()
 
 	webhookGateway := testGateway.WebhookNotification()
-	hmacer := newHmacer(testGateway)
+	hmacer := newHmacer(webhookGateway.PublicKey, webhookGateway.PrivateKey)
 
 	payload := base64.StdEncoding.EncodeToString([]byte(`
 <notification>
@@ -30,7 +30,7 @@ func TestWebhookParseMerchantAccountAccepted(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	signature := webhookGateway.PublicKey + "|" + hmacedPayload
+	signature := hmacer.publicKey + "|" + hmacedPayload
 
 	notification, err := webhookGateway.Parse(signature, payload)
 
@@ -52,7 +52,7 @@ func TestWebhookParseMerchantAccountDeclined(t *testing.T) {
 	t.Parallel()
 
 	webhookGateway := testGateway.WebhookNotification()
-	hmacer := newHmacer(testGateway)
+	hmacer := newHmacer(webhookGateway.PublicKey, webhookGateway.PrivateKey)
 
 	payload := base64.StdEncoding.EncodeToString([]byte(`
 <notification>
@@ -88,7 +88,7 @@ func TestWebhookParseMerchantAccountDeclined(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	signature := webhookGateway.PublicKey + "|" + hmacedPayload
+	signature := hmacer.publicKey + "|" + hmacedPayload
 
 	notification, err := webhookGateway.Parse(signature, payload)
 
@@ -113,7 +113,7 @@ func TestWebhookParseDisbursement(t *testing.T) {
 	t.Parallel()
 
 	webhookGateway := testGateway.WebhookNotification()
-	hmacer := newHmacer(testGateway)
+	hmacer := newHmacer(webhookGateway.PublicKey, webhookGateway.PrivateKey)
 
 	payload := base64.StdEncoding.EncodeToString([]byte(`
 <notification>
@@ -145,7 +145,7 @@ func TestWebhookParseDisbursement(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	signature := webhookGateway.PublicKey + "|" + hmacedPayload
+	signature := hmacer.publicKey + "|" + hmacedPayload
 
 	notification, err := webhookGateway.Parse(signature, payload)
 
@@ -172,7 +172,7 @@ func TestWebhookParseDisbursementException(t *testing.T) {
 	t.Parallel()
 
 	webhookGateway := testGateway.WebhookNotification()
-	hmacer := newHmacer(testGateway)
+	hmacer := newHmacer(webhookGateway.PublicKey, webhookGateway.PrivateKey)
 
 	payload := base64.StdEncoding.EncodeToString([]byte(`
 <notification>
@@ -204,7 +204,7 @@ func TestWebhookParseDisbursementException(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	signature := webhookGateway.PublicKey + "|" + hmacedPayload
+	signature := hmacer.publicKey + "|" + hmacedPayload
 
 	notification, err := webhookGateway.Parse(signature, payload)
 


### PR DESCRIPTION
What
===
Remove dependency on Braintree struct from hmacer, replacing it with an
explicit public and private key as constructor inputs.

Why
===
There's no need for the hmacer to need the full Braintree struct as
input since it only requires a public and private key. Once we add
credential types that do not include public and private keys (e.g.
access tokens) tightening hmacer's dependencies will give us a clearer
boundary for where we'll need to check we have the credentails we need
to support hmacing.

@jszwedko 