### PR TITLE
Rename ApiVersion to apiVersion

### DIFF
--- a/braintree.go
+++ b/braintree.go
@@ -10,11 +10,11 @@ import (
 
 const LibraryVersion = "0.9.0"
 
-type ApiVersion int
+type apiVersion int
 
 const (
-	ApiVersion3 ApiVersion = 3
-	ApiVersion4            = 4
+	apiVersion3 apiVersion = 3
+	apiVersion4            = 4
 )
 
 func New(env Environment, merchId, pubKey, privKey string) *Braintree {
@@ -50,10 +50,10 @@ func (g *Braintree) MerchantURL() string {
 }
 
 func (g *Braintree) execute(method, path string, xmlObj interface{}) (*Response, error) {
-	return g.executeVersion(method, path, xmlObj, ApiVersion3)
+	return g.executeVersion(method, path, xmlObj, apiVersion3)
 }
 
-func (g *Braintree) executeVersion(method, path string, xmlObj interface{}, apiVersion ApiVersion) (*Response, error) {
+func (g *Braintree) executeVersion(method, path string, xmlObj interface{}, v apiVersion) (*Response, error) {
 	var buf bytes.Buffer
 	if xmlObj != nil {
 		xmlBody, err := xml.Marshal(xmlObj)
@@ -81,7 +81,7 @@ func (g *Braintree) executeVersion(method, path string, xmlObj interface{}, apiV
 	req.Header.Set("Accept", "application/xml")
 	req.Header.Set("Accept-Encoding", "gzip")
 	req.Header.Set("User-Agent", fmt.Sprintf("Braintree Go %s", LibraryVersion))
-	req.Header.Set("X-ApiVersion", fmt.Sprintf("%d", apiVersion))
+	req.Header.Set("X-ApiVersion", fmt.Sprintf("%d", v))
 	req.SetBasicAuth(g.PublicKey, g.PrivateKey)
 
 	httpClient := g.HttpClient

--- a/payment_method_gateway.go
+++ b/payment_method_gateway.go
@@ -22,7 +22,7 @@ type PaymentMethodRequestOptions struct {
 }
 
 func (g *PaymentMethodGateway) Create(paymentMethodRequest *PaymentMethodRequest) (PaymentMethod, error) {
-	resp, err := g.executeVersion("POST", "payment_methods", paymentMethodRequest, ApiVersion4)
+	resp, err := g.executeVersion("POST", "payment_methods", paymentMethodRequest, apiVersion4)
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +34,7 @@ func (g *PaymentMethodGateway) Create(paymentMethodRequest *PaymentMethodRequest
 }
 
 func (g *PaymentMethodGateway) Update(token string, paymentMethod *PaymentMethodRequest) (PaymentMethod, error) {
-	resp, err := g.executeVersion("PUT", "payment_methods/any/"+token, paymentMethod, ApiVersion4)
+	resp, err := g.executeVersion("PUT", "payment_methods/any/"+token, paymentMethod, apiVersion4)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func (g *PaymentMethodGateway) Update(token string, paymentMethod *PaymentMethod
 }
 
 func (g *PaymentMethodGateway) Find(token string) (PaymentMethod, error) {
-	resp, err := g.executeVersion("GET", "payment_methods/any/"+token, nil, ApiVersion4)
+	resp, err := g.executeVersion("GET", "payment_methods/any/"+token, nil, apiVersion4)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (g *PaymentMethodGateway) Find(token string) (PaymentMethod, error) {
 }
 
 func (g *PaymentMethodGateway) Delete(token string) error {
-	resp, err := g.executeVersion("DELETE", "payment_methods/any/"+token, nil, ApiVersion4)
+	resp, err := g.executeVersion("DELETE", "payment_methods/any/"+token, nil, apiVersion4)
 	if err != nil {
 		return err
 	}

--- a/paypal_account_gateway.go
+++ b/paypal_account_gateway.go
@@ -5,7 +5,7 @@ type PayPalAccountGateway struct {
 }
 
 func (g *PayPalAccountGateway) Update(paypalAccount *PayPalAccount) (*PayPalAccount, error) {
-	resp, err := g.executeVersion("PUT", "payment_methods/paypal_account/"+paypalAccount.Token, paypalAccount, ApiVersion4)
+	resp, err := g.executeVersion("PUT", "payment_methods/paypal_account/"+paypalAccount.Token, paypalAccount, apiVersion4)
 	if err != nil {
 		return nil, err
 	}
@@ -17,7 +17,7 @@ func (g *PayPalAccountGateway) Update(paypalAccount *PayPalAccount) (*PayPalAcco
 }
 
 func (g *PayPalAccountGateway) Find(token string) (*PayPalAccount, error) {
-	resp, err := g.executeVersion("GET", "payment_methods/paypal_account/"+token, nil, ApiVersion4)
+	resp, err := g.executeVersion("GET", "payment_methods/paypal_account/"+token, nil, apiVersion4)
 	if err != nil {
 		return nil, err
 	}
@@ -29,7 +29,7 @@ func (g *PayPalAccountGateway) Find(token string) (*PayPalAccount, error) {
 }
 
 func (g *PayPalAccountGateway) Delete(paypalAccount *PayPalAccount) error {
-	resp, err := g.executeVersion("DELETE", "payment_methods/paypal_account/"+paypalAccount.Token, nil, ApiVersion4)
+	resp, err := g.executeVersion("DELETE", "payment_methods/paypal_account/"+paypalAccount.Token, nil, apiVersion4)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
What
===
Rename ApiVersion to apiVersion making it unexported.

Why
===
The type is only intended for internal use and no public function or
field exposes it. It also unnecessarily clutters the go docs for the
package. The type and variables were added in a recent PR but the fact
they were exported was accidental.