### PR TITLE
Add Settlement methods for SandBox

### DIFF
--- a/braintree.go
+++ b/braintree.go
@@ -126,6 +126,10 @@ func (g *Braintree) Transaction() *TransactionGateway {
 	return &TransactionGateway{g}
 }
 
+func (g *Braintree) Testing() *TestingGateway {
+	return &TestingGateway{g}
+}
+
 func (g *Braintree) PaymentMethod() *PaymentMethodGateway {
 	return &PaymentMethodGateway{g}
 }

--- a/settlement_integration_test.go
+++ b/settlement_integration_test.go
@@ -35,7 +35,7 @@ func TestSettlementBatch(t *testing.T) {
 	}
 
 	// Settle
-	tx, err = testGateway.Transaction().Settle(tx.Id)
+	tx, err = testGateway.Testing().Settle(tx.Id)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/testing_gateway.go
+++ b/testing_gateway.go
@@ -1,0 +1,42 @@
+package braintree
+
+// TestGateway exports actions only available in the sandbox environment.
+type TestingGateway struct {
+	*Braintree
+}
+
+// Settle changes the transaction's status to settle.
+func (g *TestingGateway) Settle(transactionID string) (*Transaction, error) {
+	return g.setStatus(transactionID, "settle")
+}
+
+// SettlementConfirm changes the transaction's status to settlement_confirm.
+func (g *TestingGateway) SettlementConfirm(transactionID string) (*Transaction, error) {
+	return g.setStatus(transactionID, "settlement_confirm")
+}
+
+// SettlementDecline changes the transaction's status to settlement_decline.
+func (g *TestingGateway) SettlementDecline(transactionID string) (*Transaction, error) {
+	return g.setStatus(transactionID, "settlement_decline")
+}
+
+// SettlementPending changes the transaction's status to settlement_pending.
+func (g *TestingGateway) SettlementPending(transactionID string) (*Transaction, error) {
+	return g.setStatus(transactionID, "settlement_pending")
+}
+
+func (g *TestingGateway) setStatus(transactionID, status string) (*Transaction, error) {
+	if g.Environment != Production {
+		resp, err := g.execute("PUT", "transactions/"+transactionID+"/"+status, nil)
+		if err != nil {
+			return nil, err
+		}
+		switch resp.StatusCode {
+		case 200:
+			return resp.transaction()
+		}
+		return nil, &invalidResponseError{resp}
+	} else {
+		return nil, &testOperationPerformedInProductionError{}
+	}
+}

--- a/testing_integration_test.go
+++ b/testing_integration_test.go
@@ -1,0 +1,205 @@
+package braintree
+
+import "testing"
+
+func TestSettleTransaction(t *testing.T) {
+	t.Parallel()
+
+	old_environment := testGateway.Environment
+
+	txn, err := testGateway.Transaction().Create(&Transaction{
+		Type:   "sale",
+		Amount: randomAmount(),
+		CreditCard: &CreditCard{
+			Number:         testCreditCards["visa"].Number,
+			ExpirationDate: "05/14",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	txn, err = testGateway.Transaction().SubmitForSettlement(txn.Id, txn.Amount)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testGateway.Environment = Production
+
+	_, err = testGateway.Testing().Settle(txn.Id)
+	if err.Error() != "Operation not allowed in production environment" {
+		t.Log(testGateway.Environment)
+		t.Fatal(err)
+	}
+
+	testGateway.Environment = old_environment
+
+	txn, err = testGateway.Testing().Settle(txn.Id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if txn.Status != "settled" {
+		t.Fatal(txn.Status)
+	}
+}
+
+func TestSettlementConfirmTransaction(t *testing.T) {
+	old_environment := testGateway.Environment
+
+	txn, err := testGateway.Transaction().Create(&Transaction{
+		Type:   "sale",
+		Amount: randomAmount(),
+		CreditCard: &CreditCard{
+			Number:         testCreditCards["visa"].Number,
+			ExpirationDate: "05/14",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	txn, err = testGateway.Transaction().SubmitForSettlement(txn.Id, txn.Amount)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testGateway.Environment = Production
+
+	_, err = testGateway.Testing().SettlementConfirm(txn.Id)
+	if err.Error() != "Operation not allowed in production environment" {
+		t.Log(testGateway.Environment)
+		t.Fatal(err)
+	}
+
+	testGateway.Environment = old_environment
+
+	txn, err = testGateway.Testing().SettlementConfirm(txn.Id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if txn.Status != "settlement_confirmed" {
+		t.Fatal(txn.Status)
+	}
+}
+
+func TestSettlementDeclinedTransaction(t *testing.T) {
+	old_environment := testGateway.Environment
+
+	txn, err := testGateway.Transaction().Create(&Transaction{
+		Type:   "sale",
+		Amount: randomAmount(),
+		CreditCard: &CreditCard{
+			Number:         testCreditCards["visa"].Number,
+			ExpirationDate: "05/14",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	txn, err = testGateway.Transaction().SubmitForSettlement(txn.Id, txn.Amount)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testGateway.Environment = Production
+
+	_, err = testGateway.Testing().SettlementDecline(txn.Id)
+	if err.Error() != "Operation not allowed in production environment" {
+		t.Log(testGateway.Environment)
+		t.Fatal(err)
+	}
+
+	testGateway.Environment = old_environment
+
+	txn, err = testGateway.Testing().SettlementDecline(txn.Id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if txn.Status != "settlement_declined" {
+		t.Fatal(txn.Status)
+	}
+}
+
+func TestSettlementPendingTransaction(t *testing.T) {
+	old_environment := testGateway.Environment
+
+	txn, err := testGateway.Transaction().Create(&Transaction{
+		Type:   "sale",
+		Amount: randomAmount(),
+		CreditCard: &CreditCard{
+			Number:         testCreditCards["visa"].Number,
+			ExpirationDate: "05/14",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	txn, err = testGateway.Transaction().SubmitForSettlement(txn.Id, txn.Amount)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testGateway.Environment = Production
+
+	_, err = testGateway.Testing().SettlementPending(txn.Id)
+	if err.Error() != "Operation not allowed in production environment" {
+		t.Log(testGateway.Environment)
+		t.Fatal(err)
+	}
+
+	testGateway.Environment = old_environment
+
+	txn, err = testGateway.Testing().SettlementPending(txn.Id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if txn.Status != "settlement_pending" {
+		t.Fatal(txn.Status)
+	}
+}
+
+func TestTransactionCreateSettleCheckCreditCardDetails(t *testing.T) {
+	t.Parallel()
+
+	amount := NewDecimal(10000, 2)
+	txn, err := testGateway.Transaction().Create(&Transaction{
+		Type:   "sale",
+		Amount: amount,
+		CreditCard: &CreditCard{
+			Number:         testCreditCards["discover"].Number,
+			ExpirationDate: "05/14",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if txn.PaymentInstrumentType != "credit_card" {
+		t.Fatalf("Returned payment instrument doesn't match input, expected %q, got %q",
+			"credit_card", txn.PaymentInstrumentType)
+	}
+	if txn.CreditCard.CardType != "Discover" {
+		t.Fatalf("Returned credit card detail doesn't match input, expected %q, got %q",
+			"Visa", txn.CreditCard.CardType)
+	}
+
+	txn, err = testGateway.Transaction().SubmitForSettlement(txn.Id, txn.Amount)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	txn, err = testGateway.Testing().Settle(txn.Id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if txn.Status != "settled" {
+		t.Fatal(txn.Status)
+	}
+}

--- a/transaction_gateway.go
+++ b/transaction_gateway.go
@@ -44,20 +44,9 @@ func (g *TransactionGateway) SubmitForSettlement(id string, amount ...*Decimal) 
 
 // Settle settles a transaction.
 // This action is only available in the sandbox environment.
+// Deprecated: use the Settle function on the TestingGateway instead. e.g. g.Testing().Settle(id).
 func (g *TransactionGateway) Settle(id string) (*Transaction, error) {
-	if g.Environment != Production {
-		resp, err := g.execute("PUT", "transactions/"+id+"/settle", nil)
-		if err != nil {
-			return nil, err
-		}
-		switch resp.StatusCode {
-		case 200:
-			return resp.transaction()
-		}
-		return nil, &invalidResponseError{resp}
-	} else {
-		return nil, &testOperationPerformedInProductionError{}
-	}
+	return g.Testing().Settle(id)
 }
 
 // Void voids the transaction with the specified id if it has a status of authorized or


### PR DESCRIPTION
Transaction gateway currently only supports setting transaction status to `settle`. This adds extra methods to set status to also `settlement_confirm`, `settlement_decline` and `settlement_pending`.


cc: @sadlil 
