### PR TITLE
Separate structs for Transaction request and response

### DIFF
--- a/examples/transaction/server.go
+++ b/examples/transaction/server.go
@@ -42,7 +42,7 @@ func createTransaction(w http.ResponseWriter, r *http.Request) {
 		os.Getenv("BRAINTREE_PRIV_KEY"),
 	)
 
-	tx := &braintree.Transaction{
+	tx := &braintree.TransactionRequest{
 		Type:   "sale",
 		Amount: braintree.NewDecimal(10000, 2),
 		CreditCard: &braintree.CreditCard{

--- a/merchant_account_integration_test.go
+++ b/merchant_account_integration_test.go
@@ -73,7 +73,7 @@ func TestMerchantAccountTransaction(t *testing.T) {
 
 	amount := NewDecimal(int64(randomAmount().Scale+500), 2)
 
-	tx, err := testGateway.Transaction().Create(&Transaction{
+	tx, err := testGateway.Transaction().Create(&TransactionRequest{
 		Type:   "sale",
 		Amount: amount,
 		CreditCard: &CreditCard{

--- a/settlement_integration_test.go
+++ b/settlement_integration_test.go
@@ -9,7 +9,7 @@ func TestSettlementBatch(t *testing.T) {
 	t.Parallel()
 
 	// Create a new transaction
-	tx, err := testGateway.Transaction().Create(&Transaction{
+	tx, err := testGateway.Transaction().Create(&TransactionRequest{
 		Type:               "sale",
 		Amount:             NewDecimal(1000, 2),
 		PaymentMethodNonce: FakeNonceTransactableJCB,

--- a/testing_integration_test.go
+++ b/testing_integration_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestSettleTransaction(t *testing.T) {
 	t.Parallel()
 
-	txn, err := testGateway.Transaction().Create(&Transaction{
+	txn, err := testGateway.Transaction().Create(&TransactionRequest{
 		Type:   "sale",
 		Amount: randomAmount(),
 		CreditCard: &CreditCard{
@@ -41,7 +41,7 @@ func TestSettleTransaction(t *testing.T) {
 }
 
 func TestSettlementConfirmTransaction(t *testing.T) {
-	txn, err := testGateway.Transaction().Create(&Transaction{
+	txn, err := testGateway.Transaction().Create(&TransactionRequest{
 		Type:   "sale",
 		Amount: randomAmount(),
 		CreditCard: &CreditCard{
@@ -77,7 +77,7 @@ func TestSettlementConfirmTransaction(t *testing.T) {
 }
 
 func TestSettlementDeclinedTransaction(t *testing.T) {
-	txn, err := testGateway.Transaction().Create(&Transaction{
+	txn, err := testGateway.Transaction().Create(&TransactionRequest{
 		Type:   "sale",
 		Amount: randomAmount(),
 		CreditCard: &CreditCard{
@@ -113,7 +113,7 @@ func TestSettlementDeclinedTransaction(t *testing.T) {
 }
 
 func TestSettlementPendingTransaction(t *testing.T) {
-	txn, err := testGateway.Transaction().Create(&Transaction{
+	txn, err := testGateway.Transaction().Create(&TransactionRequest{
 		Type:   "sale",
 		Amount: randomAmount(),
 		CreditCard: &CreditCard{
@@ -152,7 +152,7 @@ func TestTransactionCreateSettleCheckCreditCardDetails(t *testing.T) {
 	t.Parallel()
 
 	amount := NewDecimal(10000, 2)
-	txn, err := testGateway.Transaction().Create(&Transaction{
+	txn, err := testGateway.Transaction().Create(&TransactionRequest{
 		Type:   "sale",
 		Amount: amount,
 		CreditCard: &CreditCard{

--- a/transaction.go
+++ b/transaction.go
@@ -25,7 +25,6 @@ type Transaction struct {
 	BillingAddress              *Address                  `xml:"billing,omitempty"`
 	ShippingAddress             *Address                  `xml:"shipping,omitempty"`
 	DeviceData                  string                    `xml:"device-data,omitempty"`
-	Options                     *TransactionOptions       `xml:"options,omitempty"`
 	ServiceFeeAmount            *Decimal                  `xml:"service-fee-amount,attr,omitempty"`
 	CreatedAt                   *time.Time                `xml:"created-at,omitempty"`
 	UpdatedAt                   *time.Time                `xml:"updated-at,omitempty"`
@@ -43,6 +42,27 @@ type Transaction struct {
 	RiskData                    *RiskData                 `xml:"risk-data,omitempty"`
 	Descriptor                  *Descriptor               `xml:"descriptor,omitempty"`
 	CustomFields                customfields.CustomFields `xml:"custom-fields,omitempty"`
+}
+
+type TransactionRequest struct {
+	XMLName            string                    `xml:"transaction"`
+	CustomerID         string                    `xml:"customer-id,omitempty"`
+	Type               string                    `xml:"type,omitempty"`
+	Amount             *Decimal                  `xml:"amount"`
+	OrderId            string                    `xml:"order-id,omitempty"`
+	PaymentMethodToken string                    `xml:"payment-method-token,omitempty"`
+	PaymentMethodNonce string                    `xml:"payment-method-nonce,omitempty"`
+	MerchantAccountId  string                    `xml:"merchant-account-id,omitempty"`
+	PlanId             string                    `xml:"plan-id,omitempty"`
+	CreditCard         *CreditCard               `xml:"credit-card,omitempty"`
+	Customer           *Customer                 `xml:"customer,omitempty"`
+	BillingAddress     *Address                  `xml:"billing,omitempty"`
+	ShippingAddress    *Address                  `xml:"shipping,omitempty"`
+	DeviceData         string                    `xml:"device-data,omitempty"`
+	Options            *TransactionOptions       `xml:"options,omitempty"`
+	ServiceFeeAmount   *Decimal                  `xml:"service-fee-amount,attr,omitempty"`
+	Descriptor         *Descriptor               `xml:"descriptor,omitempty"`
+	CustomFields       customfields.CustomFields `xml:"custom-fields,omitempty"`
 }
 
 // TODO: not all transaction fields are implemented yet, here are the missing fields (add on demand)

--- a/transaction_gateway.go
+++ b/transaction_gateway.go
@@ -10,7 +10,7 @@ type TransactionGateway struct {
 }
 
 // Create initiates a transaction.
-func (g *TransactionGateway) Create(tx *Transaction) (*Transaction, error) {
+func (g *TransactionGateway) Create(tx *TransactionRequest) (*Transaction, error) {
 	resp, err := g.execute("POST", "transactions", tx)
 	if err != nil {
 		return nil, err
@@ -25,9 +25,9 @@ func (g *TransactionGateway) Create(tx *Transaction) (*Transaction, error) {
 // SubmitForSettlement submits the transaction with the specified id for settlement.
 // If the amount is omitted, the full amount is settled.
 func (g *TransactionGateway) SubmitForSettlement(id string, amount ...*Decimal) (*Transaction, error) {
-	var tx *Transaction
+	var tx *TransactionRequest
 	if len(amount) > 0 {
-		tx = &Transaction{
+		tx = &TransactionRequest{
 			Amount: amount[0],
 		}
 	}
@@ -68,9 +68,9 @@ func (g *TransactionGateway) Void(id string) (*Transaction, error) {
 // If the transaction has not yet begun settlement, use Void() instead.
 // If you do not specify an amount to refund, the entire transaction amount will be refunded.
 func (g *TransactionGateway) Refund(id string, amount ...*Decimal) (*Transaction, error) {
-	var tx *Transaction
+	var tx *TransactionRequest
 	if len(amount) > 0 {
-		tx = &Transaction{
+		tx = &TransactionRequest{
 			Amount: amount[0],
 		}
 	}

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -17,7 +17,7 @@ func randomAmount() *Decimal {
 func TestTransactionCreateSubmitForSettlementAndVoid(t *testing.T) {
 	t.Parallel()
 
-	tx, err := testGateway.Transaction().Create(&Transaction{
+	tx, err := testGateway.Transaction().Create(&TransactionRequest{
 		Type:   "sale",
 		Amount: NewDecimal(2000, 2),
 		CreditCard: &CreditCard{
@@ -72,7 +72,7 @@ func TestTransactionSearch(t *testing.T) {
 
 	txg := testGateway.Transaction()
 	createTx := func(amount *Decimal, customerName string) error {
-		_, err := txg.Create(&Transaction{
+		_, err := txg.Create(&TransactionRequest{
 			Type:   "sale",
 			Amount: amount,
 			Customer: &Customer{
@@ -121,7 +121,7 @@ func TestTransactionSearch(t *testing.T) {
 func TestTransactionSearchTime(t *testing.T) {
 	txg := testGateway.Transaction()
 	createTx := func(amount *Decimal, customerName string) error {
-		_, err := txg.Create(&Transaction{
+		_, err := txg.Create(&TransactionRequest{
 			Type:   "sale",
 			Amount: amount,
 			Customer: &Customer{
@@ -192,7 +192,7 @@ func TestTransactionSearchTime(t *testing.T) {
 func TestTransactionCreateWhenGatewayRejected(t *testing.T) {
 	t.Parallel()
 
-	_, err := testGateway.Transaction().Create(&Transaction{
+	_, err := testGateway.Transaction().Create(&TransactionRequest{
 		Type:   "sale",
 		Amount: NewDecimal(201000, 2),
 		CreditCard: &CreditCard{
@@ -218,7 +218,7 @@ func TestTransactionCreateWhenGatewayRejected(t *testing.T) {
 func TestTransactionCreateWhenGatewayRejectedFraud(t *testing.T) {
 	t.Parallel()
 
-	_, err := testGateway.Transaction().Create(&Transaction{
+	_, err := testGateway.Transaction().Create(&TransactionRequest{
 		Type:               "sale",
 		Amount:             NewDecimal(201000, 2),
 		PaymentMethodNonce: FakeNonceGatewayRejectedFraud,
@@ -249,7 +249,7 @@ func TestTransactionCreateWhenGatewayRejectedFraud(t *testing.T) {
 func TestFindTransaction(t *testing.T) {
 	t.Parallel()
 
-	createdTransaction, err := testGateway.Transaction().Create(&Transaction{
+	createdTransaction, err := testGateway.Transaction().Create(&TransactionRequest{
 		Type:   "sale",
 		Amount: randomAmount(),
 		CreditCard: &CreditCard{
@@ -290,7 +290,7 @@ func TestFindNonExistantTransaction(t *testing.T) {
 func TestTransactionDescriptorFields(t *testing.T) {
 	t.Parallel()
 
-	tx := &Transaction{
+	tx := &TransactionRequest{
 		Type:               "sale",
 		Amount:             randomAmount(),
 		PaymentMethodNonce: FakeNonceTransactable,
@@ -332,7 +332,7 @@ func TestTransactionDescriptorFields(t *testing.T) {
 func TestAllTransactionFields(t *testing.T) {
 	t.Parallel()
 
-	tx := &Transaction{
+	tx := &TransactionRequest{
 		Type:    "sale",
 		Amount:  randomAmount(),
 		OrderId: "my_custom_order",
@@ -480,7 +480,7 @@ func TestTransactionCreateFromPaymentMethodCode(t *testing.T) {
 		t.Fatal("invalid token")
 	}
 
-	tx, err := testGateway.Transaction().Create(&Transaction{
+	tx, err := testGateway.Transaction().Create(&TransactionRequest{
 		Type:               "sale",
 		CustomerID:         customer.Id,
 		Amount:             randomAmount(),
@@ -498,7 +498,7 @@ func TestTransactionCreateFromPaymentMethodCode(t *testing.T) {
 func TestTrxPaymentMethodNonce(t *testing.T) {
 	t.Parallel()
 
-	txn, err := testGateway.Transaction().Create(&Transaction{
+	txn, err := testGateway.Transaction().Create(&TransactionRequest{
 		Type:               "sale",
 		Amount:             randomAmount(),
 		PaymentMethodNonce: "fake-apple-pay-mastercard-nonce",
@@ -517,7 +517,7 @@ func TestTransactionCreateSettleAndFullRefund(t *testing.T) {
 	t.Parallel()
 
 	amount := NewDecimal(20000, 2)
-	txn, err := testGateway.Transaction().Create(&Transaction{
+	txn, err := testGateway.Transaction().Create(&TransactionRequest{
 		Type:   "sale",
 		Amount: amount,
 		CreditCard: &CreditCard{
@@ -593,7 +593,7 @@ func TestTransactionCreateSettleAndPartialRefund(t *testing.T) {
 	amount := NewDecimal(10000, 2)
 	refundAmt1 := NewDecimal(5000, 2)
 	refundAmt2 := NewDecimal(5001, 2)
-	txn, err := testGateway.Transaction().Create(&Transaction{
+	txn, err := testGateway.Transaction().Create(&TransactionRequest{
 		Type:   "sale",
 		Amount: amount,
 		CreditCard: &CreditCard{
@@ -658,7 +658,7 @@ func TestTransactionCreateWithCustomFields(t *testing.T) {
 	}
 
 	amount := NewDecimal(10000, 2)
-	txn, err := testGateway.Transaction().Create(&Transaction{
+	txn, err := testGateway.Transaction().Create(&TransactionRequest{
 		Type:               "sale",
 		Amount:             amount,
 		PaymentMethodNonce: FakeNonceTransactable,

--- a/transaction_paypal_details_integration_test.go
+++ b/transaction_paypal_details_integration_test.go
@@ -3,7 +3,7 @@ package braintree
 import "testing"
 
 func TestTransactionPayPalDetails(t *testing.T) {
-	tx, err := testGateway.Transaction().Create(&Transaction{
+	tx, err := testGateway.Transaction().Create(&TransactionRequest{
 		Type:               "sale",
 		Amount:             NewDecimal(2000, 2),
 		PaymentMethodNonce: FakeNoncePayPalOneTimePayment,
@@ -57,7 +57,7 @@ func TestTransactionPayPalDetails(t *testing.T) {
 }
 
 func TestTransactionWithoutPayPalDetails(t *testing.T) {
-	tx, err := testGateway.Transaction().Create(&Transaction{
+	tx, err := testGateway.Transaction().Create(&TransactionRequest{
 		Type:               "sale",
 		Amount:             NewDecimal(2000, 2),
 		PaymentMethodNonce: FakeNonceTransactable,


### PR DESCRIPTION
What
===
Add `TransactionRequest` to define the parameters needed for creating a
`Transaction`, instead of using `Transaction` for both the request and
response.

Why
===
The primary reason is so that we can introduce request fields that have
entirely different fields on the request and the response. e.g.
`risk-data`.

Aside from the primary reason most fields on `Transaction` are not
settable in the request and having a separate request struct more
clearly defines what a merchant can set on the request, and is more
consistent with other Braintree SDKs like the Java SDK which has a
request and response object for each model.

Notes
===
This is a significant breaking change, but we've made breaking changes
like this before as we're still pre-v1 and the exported API would
degrade quickly if we try and we continue to add new fields without
separating the request and response.