### PR TITLE
Add risk data request to transaction

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -61,6 +61,7 @@ type TransactionRequest struct {
 	DeviceData         string                    `xml:"device-data,omitempty"`
 	Options            *TransactionOptions       `xml:"options,omitempty"`
 	ServiceFeeAmount   *Decimal                  `xml:"service-fee-amount,attr,omitempty"`
+	RiskData           *RiskDataRequest          `xml:"risk-data,omitempty"`
 	Descriptor         *Descriptor               `xml:"descriptor,omitempty"`
 	CustomFields       customfields.CustomFields `xml:"custom-fields,omitempty"`
 }
@@ -141,4 +142,9 @@ type TransactionSearchResult struct {
 type RiskData struct {
 	ID       string `xml:"id"`
 	Decision string `xml:"decision"`
+}
+
+type RiskDataRequest struct {
+	CustomerBrowser string `xml:"customer-browser"`
+	CustomerIP      string `xml:"customer-ip"`
 }

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -329,6 +329,32 @@ func TestTransactionDescriptorFields(t *testing.T) {
 	}
 }
 
+func TestTransactionRiskDataFields(t *testing.T) {
+	t.Parallel()
+
+	tx := &TransactionRequest{
+		Type:               "sale",
+		Amount:             randomAmount(),
+		PaymentMethodNonce: FakeNonceTransactable,
+		RiskData: &RiskDataRequest{
+			CustomerBrowser: "Mozilla/5.0 (X11; U; Linux x86_64; en-US) AppleWebKit/540.0 (KHTML,like Gecko) Chrome/9.1.0.0 Safari/540.0",
+			CustomerIP:      "127.0.0.1",
+		},
+	}
+
+	tx2, err := testGateway.Transaction().Create(tx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if tx2.Type != tx.Type {
+		t.Fatalf("expected Type to be equal, but %s was not %s", tx2.Type, tx.Type)
+	}
+	if tx2.Amount.Cmp(tx.Amount) != 0 {
+		t.Fatalf("expected Amount to be equal, but %s was not %s", tx2.Amount, tx.Amount)
+	}
+}
+
 func TestAllTransactionFields(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
What
===
Add transaction request fields for risk data for customer browser and
customer ID.

Why
===
The fields aren't settable, and requested in #127.

Notes
===
Should be merged to `master` after #129.