### PR TITLE
Add CurrencyISOCode to Transaction

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -13,6 +13,7 @@ type Transaction struct {
 	CustomerID                  string                    `xml:"customer-id,omitempty"`
 	Status                      string                    `xml:"status,omitempty"`
 	Type                        string                    `xml:"type,omitempty"`
+	CurrencyISOCode             string                    `xml:"currency-iso-code,omitempty"`
 	Amount                      *Decimal                  `xml:"amount"`
 	OrderId                     string                    `xml:"order-id,omitempty"`
 	PaymentMethodToken          string                    `xml:"payment-method-token,omitempty"`
@@ -47,7 +48,6 @@ type Transaction struct {
 // TODO: not all transaction fields are implemented yet, here are the missing fields (add on demand)
 //
 // <transaction>
-//   <currency-iso-code>USD</currency-iso-code>
 //   <custom-fields>
 //   </custom-fields>
 //   <avs-error-response-code nil="true"></avs-error-response-code>

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -373,6 +373,9 @@ func TestAllTransactionFields(t *testing.T) {
 	if tx2.Type != tx.Type {
 		t.Fatalf("expected Type to be equal, but %s was not %s", tx2.Type, tx.Type)
 	}
+	if tx2.CurrencyISOCode != "USD" {
+		t.Fatalf("expected CurrencyISOCode to be %s but was %s", "USD", tx2.CurrencyISOCode)
+	}
 	if tx2.Amount.Cmp(tx.Amount) != 0 {
 		t.Fatalf("expected Amount to be equal, but %s was not %s", tx2.Amount, tx.Amount)
 	}


### PR DESCRIPTION
What
===
Add CurrencyISOCode to Transaction on deserialization.

Why
===
The field was listed in the list of fields we have not yet included in
the Transaction struct. Adding it to the supported list was requested in
issue #127 and it's simple enough for us to include.