### PR TITLE
Improve tests for webhook verification

### DIFF
--- a/hmac_test.go
+++ b/hmac_test.go
@@ -25,12 +25,6 @@ func TestHmacerParseSignature(t *testing.T) {
 			SignatureKeyPairs: "pubkey2|the_signature",
 			ExpectedError:     SignatureError{message: "Signature-key pair contains the wrong public key!"},
 		},
-		// TODO: Add support for multiple signatures
-		// {
-		// 	Description:       "Multiple signatures (one matching)",
-		// 	SignatureKeyPairs: "pubkey|the_signature&pubkey2|the_signature",
-		// 	ExpectedSignature: "the_signature",
-		// },
 		{
 			Description:       "Invalid signatures (too many pipes)",
 			SignatureKeyPairs: "pubkey|the_signature|the_signature",
@@ -71,13 +65,6 @@ func TestHmacerVerifySignature(t *testing.T) {
 			Payload:       "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPG5vdGlm\naWNhdGlvbj4KICA8a2luZD5jaGVjazwva2luZD4KICA8dGltZXN0YW1wIHR5\ncGU9ImRhdGV0aW1lIj4yMDE3LTA0LTI0VDA0OjI1OjEwWjwvdGltZXN0YW1w\nPgogIDxzdWJqZWN0PgogICAgPGNoZWNrIHR5cGU9ImJvb2xlYW4iPnRydWU8\nL2NoZWNrPgogIDwvc3ViamVjdD4KPC9ub3RpZmljYXRpb24+Cg==\n",
 			ExpectedValid: true,
 		},
-		// TODO: Add support for multiple signatures
-		// {
-		// 	Description:   "Multiple signature (valid)",
-		// 	Signature:     "4zn8jg4gdmzyvcyd|dd6390bc9d75985f0cc986d5d5f55fcdb52531cb&cd7jwvrw8jytyfm3|d7fdd777e30a1fd93b58770d7682b577b461cf6f&jkq28pcxj4r85dwr|96dd50905f51f6de1c24790c4d77aa460cb55a3d",
-		// 	Payload:       "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPG5vdGlm\naWNhdGlvbj4KICA8a2luZD5jaGVjazwva2luZD4KICA8dGltZXN0YW1wIHR5\ncGU9ImRhdGV0aW1lIj4yMDE3LTA0LTI0VDA0OjI1OjEwWjwvdGltZXN0YW1w\nPgogIDxzdWJqZWN0PgogICAgPGNoZWNrIHR5cGU9ImJvb2xlYW4iPnRydWU8\nL2NoZWNrPgogIDwvc3ViamVjdD4KPC9ub3RpZmljYXRpb24+Cg==\n",
-		// 	ExpectedValid: true,
-		// },
 		{
 			Description:   "Single signature (invalid)",
 			Signature:     "jkq28pcxj4r85dwr|4af78bab15cc58195871c636c786716f34cd9711",

--- a/hmac_test.go
+++ b/hmac_test.go
@@ -7,58 +7,97 @@ import (
 func TestHmacerParseSignature(t *testing.T) {
 	t.Parallel()
 
-	apiKey := testGateway.credentials.(apiKey)
-	hmacer := newHmacer(apiKey.publicKey, apiKey.privateKey)
+	hmacer := newHmacer("pubkey", "privkey")
 
-	// Happy path
-	realSignature, err := hmacer.parseSignature(hmacer.publicKey + "|my_actual_signature")
-	if err != nil {
-		t.Fatal(err)
-	} else if realSignature != "my_actual_signature" {
-		t.Fatal("parseSignature returned wrong signature")
+	testCases := []struct {
+		Description       string
+		SignatureKeyPairs string
+		ExpectedSignature string
+		ExpectedError     error
+	}{
+		{
+			Description:       "Single signature",
+			SignatureKeyPairs: "pubkey|the_signature",
+			ExpectedSignature: "the_signature",
+		},
+		{
+			Description:       "Single signature (not matching)",
+			SignatureKeyPairs: "pubkey2|the_signature",
+			ExpectedError:     SignatureError{message: "Signature-key pair contains the wrong public key!"},
+		},
+		// TODO: Add support for multiple signatures
+		// {
+		// 	Description:       "Multiple signatures (one matching)",
+		// 	SignatureKeyPairs: "pubkey|the_signature&pubkey2|the_signature",
+		// 	ExpectedSignature: "the_signature",
+		// },
+		{
+			Description:       "Invalid signatures (too many pipes)",
+			SignatureKeyPairs: "pubkey|the_signature|the_signature",
+			ExpectedError:     SignatureError{message: "Signature-key pair contains more than one |"},
+		},
+		{
+			Description:       "Invalid signature (no pipe)",
+			SignatureKeyPairs: "pubkeythe_signature",
+			ExpectedError:     SignatureError{message: "Signature-key pair does not contain |"},
+		},
 	}
 
-	// Test hmacer rejects an incorrect public key
-	_, err = hmacer.parseSignature("some_random_public_key|my_actual_signature")
-	if err == nil {
-		t.Fatal("Did not receive an error when the wrong public key was passed")
-	}
-
-	// Test hmacer rejects a signature-key pair with more than one pipe
-	_, err = hmacer.parseSignature("some_random_public_key|some_other_stuff|my_actual_signature")
-	if err == nil {
-		t.Fatal("Did not receive an error when the wrong public key was passed")
-	}
-
-	// Test hmacer rejects a singature-key pair with no pipes
-	_, err = hmacer.parseSignature("some_random_public_key&my_actual_signature")
-	if err == nil {
-		t.Fatal("Did not receive an error when the wrong public key was passed")
+	for _, tc := range testCases {
+		signature, err := hmacer.parseSignature(tc.SignatureKeyPairs)
+		if err != nil && (tc.ExpectedError == nil || err.(SignatureError) != tc.ExpectedError) {
+			t.Errorf("Test Case %q with Signature %q encountered error %#v want %#v", tc.Description, tc.SignatureKeyPairs, err, tc.ExpectedError)
+		} else if signature != tc.ExpectedSignature {
+			t.Errorf("Test Case %q with Signature %q returned %#v want %#v", tc.Description, tc.SignatureKeyPairs, signature, tc.ExpectedSignature)
+		}
 	}
 }
 
 func TestHmacerVerifySignature(t *testing.T) {
 	t.Parallel()
 
-	hmacer := newHmacer("my_public_key", "my_private_key")
-	signatureKeyPair := hmacer.publicKey + "|fa654fa4fe5537934960c483dbb0ee575d64b6ad"
-	payload := "my_random_value"
+	hmacer := newHmacer("jkq28pcxj4r85dwr", "66062a3876e2dc298f2195f0bf173f5a")
 
-	// Happy path
-	verified, err := hmacer.verifySignature(signatureKeyPair, payload)
-
-	if err != nil {
-		t.Fatal(err)
-	} else if !verified {
-		t.Fatal("Did not verify correct signature")
+	testCases := []struct {
+		Description   string
+		Signature     string
+		Payload       string
+		ExpectedError error
+		ExpectedValid bool
+	}{
+		{
+			Description:   "Single signature (valid)",
+			Signature:     "jkq28pcxj4r85dwr|4af78bab15cc58195871c636c786716f34cd9711",
+			Payload:       "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPG5vdGlm\naWNhdGlvbj4KICA8a2luZD5jaGVjazwva2luZD4KICA8dGltZXN0YW1wIHR5\ncGU9ImRhdGV0aW1lIj4yMDE3LTA0LTI0VDA0OjI1OjEwWjwvdGltZXN0YW1w\nPgogIDxzdWJqZWN0PgogICAgPGNoZWNrIHR5cGU9ImJvb2xlYW4iPnRydWU8\nL2NoZWNrPgogIDwvc3ViamVjdD4KPC9ub3RpZmljYXRpb24+Cg==\n",
+			ExpectedValid: true,
+		},
+		// TODO: Add support for multiple signatures
+		// {
+		// 	Description:   "Multiple signature (valid)",
+		// 	Signature:     "4zn8jg4gdmzyvcyd|dd6390bc9d75985f0cc986d5d5f55fcdb52531cb&cd7jwvrw8jytyfm3|d7fdd777e30a1fd93b58770d7682b577b461cf6f&jkq28pcxj4r85dwr|96dd50905f51f6de1c24790c4d77aa460cb55a3d",
+		// 	Payload:       "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPG5vdGlm\naWNhdGlvbj4KICA8a2luZD5jaGVjazwva2luZD4KICA8dGltZXN0YW1wIHR5\ncGU9ImRhdGV0aW1lIj4yMDE3LTA0LTI0VDA0OjI1OjEwWjwvdGltZXN0YW1w\nPgogIDxzdWJqZWN0PgogICAgPGNoZWNrIHR5cGU9ImJvb2xlYW4iPnRydWU8\nL2NoZWNrPgogIDwvc3ViamVjdD4KPC9ub3RpZmljYXRpb24+Cg==\n",
+		// 	ExpectedValid: true,
+		// },
+		{
+			Description:   "Single signature (invalid)",
+			Signature:     "jkq28pcxj4r85dwr|4af78bab15cc58195871c636c786716f34cd9711",
+			Payload:       "payloadthatdoesntmatchsignature",
+			ExpectedValid: false,
+		},
+		{
+			Description:   "Single signature (unknown public key)",
+			Signature:     "cd7jwvrw8jytyfm3|d7fdd777e30a1fd93b58770d7682b577b461cf6f&jkq28pcxj4r85dwr",
+			Payload:       "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPG5vdGlm\naWNhdGlvbj4KICA8a2luZD5jaGVjazwva2luZD4KICA8dGltZXN0YW1wIHR5\ncGU9ImRhdGV0aW1lIj4yMDE3LTA0LTI0VDA0OjI1OjEwWjwvdGltZXN0YW1w\nPgogIDxzdWJqZWN0PgogICAgPGNoZWNrIHR5cGU9ImJvb2xlYW4iPnRydWU8\nL2NoZWNrPgogIDwvc3ViamVjdD4KPC9ub3RpZmljYXRpb24+Cg==\n",
+			ExpectedError: SignatureError{message: "Signature-key pair contains the wrong public key!"},
+		},
 	}
 
-	// Test hmacer does not verify when the payload has been modified
-	verified, err = hmacer.verifySignature(signatureKeyPair, payload+"a bad man in the middle")
-
-	if err != nil {
-		t.Fatal(err)
-	} else if verified {
-		t.Fatal("HMACer verified invalid signature.")
+	for _, tc := range testCases {
+		valid, err := hmacer.verifySignature(tc.Signature, tc.Payload)
+		if err != nil && (tc.ExpectedError == nil || err.(SignatureError) != tc.ExpectedError) {
+			t.Errorf("Test Case %q with Signature %q and Payload %q encountered error %#v want %#v", tc.Description, tc.Signature, tc.Payload, err, tc.ExpectedError)
+		} else if valid != tc.ExpectedValid {
+			t.Errorf("Test Case %q with Signature %q and Payload %q was valid %#v want %#v", tc.Description, tc.Signature, tc.Payload, valid, tc.ExpectedValid)
+		}
 	}
 }


### PR DESCRIPTION
What
===
Replace the hmacer tests that validated the hmacer logic can parse and verify signatures on webhook notifications, with table driven tests.

Why
===
Table driven tests make it easier to add additional test cases.

PR #123 fixes the multiple signature issue, but doesn't provide any tests. When I went to add new tests it was easier to reorganize the code into table driven tests, leading to this PR. Once this PR is merged I'll make changes to #123 to fill out the multiple signature test cases before merging it.