### PR TITLE
Export the environmentFromName method

### DIFF
--- a/credentials_access_token.go
+++ b/credentials_access_token.go
@@ -16,7 +16,7 @@ func newAccessToken(accessTokenStr string) (credentials, error) {
 	if len(parts) < 3 || parts[0] != "access_token" {
 		return nil, errors.New("access token is not of expected format")
 	}
-	env, err := environmentFromName(parts[1])
+	env, err := EnvironmentFromName(parts[1])
 	if err != nil {
 		return nil, errors.New("access token is for unsupported environment, " + err.Error())
 	}

--- a/environment.go
+++ b/environment.go
@@ -20,7 +20,7 @@ var (
 	Production  = NewEnvironment("https://www.braintreegateway.com")
 )
 
-func environmentFromName(name string) (Environment, error) {
+func EnvironmentFromName(name string) (Environment, error) {
 	switch name {
 	case "development":
 		return Development, nil


### PR DESCRIPTION
When updating existing code with the newest repo updates, I encountered that I could no longer use my config file string for the Braintree environment as in previous versions. Is there a reason the environmentFromName method is private, or could it be made public?