### PR TITLE
Add ParseRequest to WebhookNotificationGateway

### DIFF
--- a/webhook_notification.go
+++ b/webhook_notification.go
@@ -6,6 +6,8 @@ import (
 )
 
 const (
+	Check = "check"
+
 	DisbursementWebhook                      = "disbursement"
 	DisbursementExceptionWebhook             = "disbursement_exception"
 	SubscriptionCanceledWebhook              = "subscription_canceled"

--- a/webhook_notification.go
+++ b/webhook_notification.go
@@ -6,8 +6,7 @@ import (
 )
 
 const (
-	Check = "check"
-
+	CheckWebhook                             = "check"
 	DisbursementWebhook                      = "disbursement"
 	DisbursementExceptionWebhook             = "disbursement_exception"
 	SubscriptionCanceledWebhook              = "subscription_canceled"

--- a/webhook_notification_gateway.go
+++ b/webhook_notification_gateway.go
@@ -3,11 +3,18 @@ package braintree
 import (
 	"encoding/base64"
 	"encoding/xml"
+	"net/http"
 )
 
 type WebhookNotificationGateway struct {
 	*Braintree
 	apiKey apiKey
+}
+
+func (w *WebhookNotificationGateway) ParseRequest(r *http.Request) (*WebhookNotification, error) {
+	signature := r.PostFormValue("bt_signature")
+	payload := r.PostFormValue("bt_payload")
+	return w.Parse(signature, payload)
 }
 
 func (w *WebhookNotificationGateway) Parse(signature, payload string) (*WebhookNotification, error) {

--- a/webhook_notification_test.go
+++ b/webhook_notification_test.go
@@ -26,7 +26,7 @@ func TestWebhookParseRequest(t *testing.T) {
 
 	if err != nil {
 		t.Fatal(err)
-	} else if notification.Kind != Check {
+	} else if notification.Kind != CheckWebhook {
 		t.Fatal("Incorrect Notification kind, expected check got", notification.Kind)
 	}
 }

--- a/webhook_notification_test.go
+++ b/webhook_notification_test.go
@@ -2,7 +2,8 @@ package braintree
 
 import (
 	"encoding/base64"
-	"net/http/httptest"
+	"io/ioutil"
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -13,8 +14,13 @@ func TestWebhookParseRequest(t *testing.T) {
 	gateway := New(Sandbox, "mid", "sz9g7zhxz8838v7h", "0c809a2d2e8f4e4c817900ff441c9554")
 	webhookGateway := gateway.WebhookNotification()
 
-	body := "bt_signature=sz9g7zhxz8838v7h%7C4b532339b3107eae876d7637d59217858f320098&bt_payload=PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPG5vdGlm%0AaWNhdGlvbj4KICA8a2luZD5jaGVjazwva2luZD4KICA8dGltZXN0YW1wIHR5%0AcGU9ImRhdGV0aW1lIj4yMDE3LTA0LTI2VDA3OjEyOjI0WjwvdGltZXN0YW1w%0APgogIDxzdWJqZWN0PgogICAgPGNoZWNrIHR5cGU9ImJvb2xlYW4iPnRydWU8%0AL2NoZWNrPgogIDwvc3ViamVjdD4KPC9ub3RpZmljYXRpb24%2BCg%3D%3D%0A"
-	r := httptest.NewRequest("POST", "/webhook", strings.NewReader(body))
+	body := strings.NewReader("bt_signature=sz9g7zhxz8838v7h%7C4b532339b3107eae876d7637d59217858f320098&bt_payload=PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPG5vdGlm%0AaWNhdGlvbj4KICA8a2luZD5jaGVjazwva2luZD4KICA8dGltZXN0YW1wIHR5%0AcGU9ImRhdGV0aW1lIj4yMDE3LTA0LTI2VDA3OjEyOjI0WjwvdGltZXN0YW1w%0APgogIDxzdWJqZWN0PgogICAgPGNoZWNrIHR5cGU9ImJvb2xlYW4iPnRydWU8%0AL2NoZWNrPgogIDwvc3ViamVjdD4KPC9ub3RpZmljYXRpb24%2BCg%3D%3D%0A")
+	r := &http.Request{
+		Method:        "POST",
+		Header:        http.Header{"Content-Type": {"application/x-www-form-urlencoded"}},
+		ContentLength: int64(body.Len()),
+		Body:          ioutil.NopCloser(body),
+	}
 
 	notification, err := webhookGateway.ParseRequest(r)
 

--- a/webhook_notification_test.go
+++ b/webhook_notification_test.go
@@ -2,8 +2,28 @@ package braintree
 
 import (
 	"encoding/base64"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
+
+func TestWebhookParseRequest(t *testing.T) {
+	t.Parallel()
+
+	gateway := New(Sandbox, "mid", "sz9g7zhxz8838v7h", "0c809a2d2e8f4e4c817900ff441c9554")
+	webhookGateway := gateway.WebhookNotification()
+
+	body := "bt_signature=sz9g7zhxz8838v7h%7C4b532339b3107eae876d7637d59217858f320098&bt_payload=PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPG5vdGlm%0AaWNhdGlvbj4KICA8a2luZD5jaGVjazwva2luZD4KICA8dGltZXN0YW1wIHR5%0AcGU9ImRhdGV0aW1lIj4yMDE3LTA0LTI2VDA3OjEyOjI0WjwvdGltZXN0YW1w%0APgogIDxzdWJqZWN0PgogICAgPGNoZWNrIHR5cGU9ImJvb2xlYW4iPnRydWU8%0AL2NoZWNrPgogIDwvc3ViamVjdD4KPC9ub3RpZmljYXRpb24%2BCg%3D%3D%0A"
+	r := httptest.NewRequest("POST", "/webhook", strings.NewReader(body))
+
+	notification, err := webhookGateway.ParseRequest(r)
+
+	if err != nil {
+		t.Fatal(err)
+	} else if notification.Kind != Check {
+		t.Fatal("Incorrect Notification kind, expected check got", notification.Kind)
+	}
+}
 
 func TestWebhookParseMerchantAccountAccepted(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
What
===
Add `ParseRequest` to `WebhookNotificationGateway` that takes a webhook
notification `http.Request`.

Why
===
To simplify unpacking webhook notifications. Since most developers will
be using the stdlib http.Request struct, we can unpack the fields rather
than requiring them to do so.

Refs
===
https://github.com/lionelbarrow/braintree-go/issues/139#issuecomment-297053267

@RichardKnop 