### PR TITLE
Added WebhookTestingGateway for testing purposes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,48 @@ source .default.env
 go test ./...
 ```
 
+### Webhook Integration Testing
+
+You can use the `WebhookTestingGateway` to write your own integration tests to verify your application is processing incoming webhook notifications correctly.
+
+A simple example:
+
+```go
+package integration_test
+
+import (
+  "testing"
+  "net/http/httptest"
+
+  "github.com/lionelbarrow/braintree-go"
+)
+
+func TestMyWebhook(t *testing.T) {
+  bt := braintree.New(
+    braintree.Sandbox,
+    "merchaint_id",
+    "public_key",
+    "private_key",
+  )
+
+  r, err := bt.WebhookTesting().Request(
+    braintree.SubscriptionChargedSuccessfullyWebhook,
+    "123", // id
+  )
+  if err != nil {
+    t.Fatal(err)
+  }
+
+  // You can now send the payload and signature to your webhook handler
+  // and test your application's busines logic
+
+  w := httptest.NewRecorder()
+  router.ServeHTTP(w, r)
+
+  // assertions
+}
+```
+
 ### License
 
 The MIT License (MIT)

--- a/braintree.go
+++ b/braintree.go
@@ -140,6 +140,14 @@ func (g *Braintree) Testing() *TestingGateway {
 	return &TestingGateway{g}
 }
 
+func (g *Braintree) WebhookTesting() *WebhookTestingGateway {
+	if apiKey, ok := g.credentials.(apiKey); !ok {
+		panic(errors.New("WebhookTesting can only be used with Braintree Credentials that are API Keys."))
+	} else {
+		return &WebhookTestingGateway{Braintree: g, apiKey: apiKey}
+	}
+}
+
 func (g *Braintree) PaymentMethod() *PaymentMethodGateway {
 	return &PaymentMethodGateway{g}
 }

--- a/testing_gateway.go
+++ b/testing_gateway.go
@@ -1,6 +1,6 @@
 package braintree
 
-// TestGateway exports actions only available in the sandbox environment.
+// TestingGateway exports actions only available in the sandbox environment.
 type TestingGateway struct {
 	*Braintree
 }

--- a/webhook_notification.go
+++ b/webhook_notification.go
@@ -23,6 +23,13 @@ const (
 	PartnerMerchantConnectedWebhook    = "partner_merchant_connected"
 	PartnerMerchantDisconnectedWebhook = "partner_merchant_disconnected"
 	PartnerMerchantDeclinedWebhook     = "partner_merchant_declined"
+
+	TransactionSettledWebhook            = "transaction_settled"
+	TransactionSettlementDeclinedWebhook = "transaction_settlement_declined"
+	DisputeOpenedWebhook                 = "dispute_opened"
+	DisputeLostWebhook                   = "dispute_lost"
+	DisputeWonWebhook                    = "dispute_won"
+	AccountUpdaterDailyReportWebhook     = "account_updater_daily_report"
 )
 
 type WebhookNotification struct {

--- a/webhook_testing_gateway.go
+++ b/webhook_testing_gateway.go
@@ -1,0 +1,434 @@
+package braintree
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"text/template"
+)
+
+var payloadTemplate = `
+<notification>
+	<timestamp type="datetime">%s</timestamp>
+	<kind>%s</kind>
+	<subject>%s</subject>
+</notification>
+`
+
+// WebhookTestingGateway exports actions only available in the sandbox environment.
+type WebhookTestingGateway struct {
+	*Braintree
+	apiKey apiKey
+}
+
+// Request simulates an incoming webhook notification request
+func (g *WebhookTestingGateway) Request(kind, id string) (*http.Request, error) {
+	payload := g.SamplePayload(kind, id)
+	signature, err := g.SignPayload(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	form := url.Values{}
+	form.Add("bt_signature", signature)
+	form.Add("bt_payload", payload)
+
+	body := form.Encode()
+	return &http.Request{
+		Method:        "POST",
+		Header:        http.Header{"Content-Type": {"application/x-www-form-urlencoded"}},
+		ContentLength: int64(len(body)),
+		Body:          ioutil.NopCloser(strings.NewReader(body)),
+	}, nil
+}
+
+// SamplePayload builds a sample payload of the given kind, different kind of
+// notifications are defined as constants in webhook_notification.go
+// id represents an id used in XML subject of the specified kind
+func (g *WebhookTestingGateway) SamplePayload(kind, id string) string {
+	datetime := time.Now().UTC().Format(time.RFC3339)
+	payload := fmt.Sprintf(
+		payloadTemplate,
+		datetime,
+		kind,
+		g.subjectXML(kind, id),
+	)
+	encodedpayload := base64.StdEncoding.EncodeToString([]byte(payload))
+	return strings.Replace(encodedpayload, "\r", "", -1)
+}
+
+// SignPayload signs payload and returns HMAC signature
+func (g *WebhookTestingGateway) SignPayload(payload string) (string, error) {
+	hmacer := newHmacer(g.apiKey.publicKey, g.apiKey.privateKey)
+	hmacedPayload, err := hmacer.hmac(payload)
+	if err != nil {
+		return "", err
+	}
+	return hmacer.publicKey + "|" + hmacedPayload, nil
+}
+
+func (g *WebhookTestingGateway) subjectXML(kind, id string) string {
+	switch kind {
+	case CheckWebhook:
+		return g.checkXML()
+	case SubMerchantAccountApprovedWebhook:
+		return g.merchantAccountXMLApproved(id)
+	case SubMerchantAccountDeclinedWebhook:
+		return g.merchantAccountXMLDeclined(id)
+	case TransactionDisbursedWebhook:
+		return g.transactionDisbursedXML(id)
+	case TransactionSettledWebhook:
+		return g.transactionSettledXML(id)
+	case TransactionSettlementDeclinedWebhook:
+		return g.transactionSettlementDeclinedXML(id)
+	case DisbursementWebhook:
+		return g.disbursementXML(id)
+	case DisputeOpenedWebhook:
+		return g.disputeOpenedXML(id)
+	case DisputeLostWebhook:
+		return g.disputeLostXML(id)
+	case DisputeWonWebhook:
+		return g.disputeWonXML(id)
+	case DisbursementExceptionWebhook:
+		return g.disbursementExceptionXML(id)
+	case PartnerMerchantConnectedWebhook:
+		return g.partnerMerchantConnectedXML(id)
+	case PartnerMerchantDisconnectedWebhook:
+		return g.partnerMerchantDisconnectedXML(id)
+	case PartnerMerchantDeclinedWebhook:
+		return g.partnerMerchantDeclinedXML(id)
+	case SubscriptionChargedSuccessfullyWebhook:
+		return g.subscriptionChargedSuccessfullyXML(id)
+	case AccountUpdaterDailyReportWebhook:
+		return g.accountUpdaterDailyReportXML(id)
+	default:
+		return g.subscriptionXML(id)
+	}
+}
+
+func (g *WebhookTestingGateway) checkXML() string {
+	return `<check type="boolean">true</check>`
+}
+
+func (g *WebhookTestingGateway) merchantAccountXMLApproved(id string) string {
+	return g.sub(
+		id,
+		`
+		<merchant_account>
+			<id>{{ $.ID }}</id>
+			<master_merchant_account>
+				<id>master_ma_for_{{ $.ID }}</id>
+				<status>active</status>
+			</master_merchant_account>
+			<status>active</status>
+		</merchant_account>
+		`,
+	)
+}
+
+func (g *WebhookTestingGateway) merchantAccountXMLDeclined(id string) string {
+	return g.sub(
+		id,
+		`
+		<api-error-response>
+			<message>Credit score is too low</message>
+			<errors type="array"/>
+				<merchant-account>
+					<errors type="array">
+						<error>
+							<code>82621</code>
+							<message>Credit score is too low</message>
+							<attribute type="symbol">base</attribute>
+						</error>
+					</errors>
+				</merchant-account>
+			</errors>
+			<merchant-account>
+				<id>{{ $.ID }}</id>
+				<status>suspended</status>
+				<master-merchant-account>
+					<id>master_ma_for_{{ $.ID }}</id>
+					<status>suspended</status>
+				</master-merchant-account>
+			</merchant-account>
+		</api-error-response>
+		`,
+	)
+}
+
+func (g *WebhookTestingGateway) subscriptionXML(id string) string {
+	return g.sub(
+		id,
+		`
+		<subscription>
+			<id>{{ $.ID }}</id>
+			<transactions type="array">
+			</transactions>
+			<add_ons type="array">
+			</add_ons>
+			<discounts type="array">
+			</discounts>
+		</subscription>
+		`,
+	)
+}
+
+func (g *WebhookTestingGateway) subscriptionChargedSuccessfullyXML(id string) string {
+	return g.sub(
+		id,
+		`
+		<subscription>
+			<id>{{ $.ID }}</id>
+			<transactions type="array">
+				<transaction>
+					<id>{{ $.ID }}</id>
+					<status>submitted_for_settlement</status>
+					<amount>49.99</amount>
+				</transaction>
+			</transactions>
+			<add_ons type="array">
+			</add_ons>
+			<discounts type="array">
+			</discounts>
+		</subscription>
+		`,
+	)
+}
+
+func (g *WebhookTestingGateway) transactionDisbursedXML(id string) string {
+	return g.sub(
+		id,
+		`
+		<transaction>
+			<id>{{ $.ID }}</id>
+			<amount>100</amount>
+			<disbursement-details>
+				<disbursement-date type="date">2013-07-09</disbursement-date>
+			</disbursement-details>
+		</transaction>
+		`,
+	)
+}
+
+func (g *WebhookTestingGateway) transactionSettledXML(id string) string {
+	return g.sub(
+		id,
+		`
+		<transaction>
+			<id>{{ $.ID}}</id>
+			<status>settled</status>
+			<type>sale</type>
+			<currency-iso-code>USD</currency-iso-code>
+			<amount>100.00</amount>
+			<merchant-account-id>ogaotkivejpfayqfeaimuktty</merchant-account-id>
+			<payment-instrument-type>us_bank_account</payment-instrument-type>
+			<us-bank-account>
+				<routing-number>123456789</routing-number>
+				<last-4>1234</last-4>
+				<account-type>checking</account-type>
+				<account-holder-name>Dan Schulman</account-holder-name>
+			</us-bank-account>
+		</transaction>
+		`,
+	)
+}
+
+func (g *WebhookTestingGateway) transactionSettlementDeclinedXML(id string) string {
+	return g.sub(
+		id,
+		`
+		<transaction>
+			<id>{{ $.ID }}</id>
+			<status>settlement_declined</status>
+			<type>sale</type>
+			<currency-iso-code>USD</currency-iso-code>
+			<amount>100.00</amount>
+			<merchant-account-id>ogaotkivejpfayqfeaimuktty</merchant-account-id>
+			<payment-instrument-type>us_bank_account</payment-instrument-type>
+			<us-bank-account>
+				<routing-number>123456789</routing-number>
+				<last-4>1234</last-4>
+				<account-type>checking</account-type>
+				<account-holder-name>Dan Schulman</account-holder-name>
+			</us-bank-account>
+		</transaction>
+		`,
+	)
+}
+
+func (g *WebhookTestingGateway) disputeOpenedXML(id string) string {
+	return g.sub(
+		id,
+		`
+		<dispute>
+			<amount>250.00</amount>
+			<currency-iso-code>USD</currency-iso-code>
+			<received-date type="date">2014-03-01</received-date>
+			<reply-by-date type="date">2014-03-21</reply-by-date>
+			<kind>chargeback</kind>
+			<status>open</status>
+			<reason>fraud</reason>
+			<id>{{ $.ID }}</id>
+			<transaction>
+				<id>{{ $.ID }}</id>
+				<amount>250.00</amount>
+			</transaction>
+			<date-opened type="date">2014-03-21</date-opened>
+		</dispute>
+		`,
+	)
+}
+
+func (g *WebhookTestingGateway) disputeLostXML(id string) string {
+	return g.sub(
+		id,
+		`
+		<dispute>
+			<amount>250.00</amount>
+			<currency-iso-code>USD</currency-iso-code>
+			<received-date type="date">2014-03-01</received-date>
+			<reply-by-date type="date">2014-03-21</reply-by-date>
+			<kind>chargeback</kind>
+			<status>lost</status>
+			<reason>fraud</reason>
+			<id>{{ $.ID }}</id>
+			<transaction>
+				<id>{{ $.ID }}</id>
+				<amount>250.00</amount>
+			</transaction>
+			<date-opened type="date">2014-03-21</date-opened>
+		</dispute>
+		`,
+	)
+}
+
+func (g *WebhookTestingGateway) disputeWonXML(id string) string {
+	return g.sub(
+		id,
+		`
+		<dispute>
+			<amount>250.00</amount>
+			<currency-iso-code>USD</currency-iso-code>
+			<received-date type="date">2014-03-01</received-date>
+			<reply-by-date type="date">2014-03-21</reply-by-date>
+			<kind>chargeback</kind>
+			<status>won</status>
+			<reason>fraud</reason>
+			<id>{{ $.ID }}</id>
+			<transaction>
+				<id>{{ $.ID }}</id>
+				<amount>250.00</amount>
+			</transaction>
+			<date-opened type="date">2014-03-21</date-opened>
+			<date-won type="date">2014-03-22</date-won>
+		</dispute>
+		`,
+	)
+}
+
+func (g *WebhookTestingGateway) disbursementXML(id string) string {
+	return g.sub(
+		id,
+		`
+		<disbursement>
+			<id>{{ $.ID }}</id>
+			<transaction-ids type="array">
+				<item>afv56j</item>
+				<item>kj8hjk</item>
+			</transaction-ids>
+			<success type="boolean">true</success>
+			<retry type="boolean">false</retry>
+			<merchant-account>
+				<id>merchant_account_token</id>
+				<currency-iso-code>USD</currency-iso-code>
+				<sub-merchant-account type="boolean">false</sub-merchant-account>
+				<status>active</status>
+			</merchant-account>
+			<amount>100.00</amount>
+			<disbursement-date type="date">2014-02-10</disbursement-date>
+			<exception-message nil="true"/>
+			<follow-up-action nil="true"/>
+		</disbursement>
+		`,
+	)
+}
+
+func (g *WebhookTestingGateway) disbursementExceptionXML(id string) string {
+	return g.sub(
+		id,
+		`
+		<disbursement>
+			<id>{{ $.ID }}</id>
+			<transaction-ids type="array">
+				<item>afv56j</item>
+				<item>kj8hjk</item>
+			</transaction-ids>
+			<success type="boolean">false</success>
+			<retry type="boolean">false</retry>
+			<merchant-account>
+				<id>merchant_account_token</id>
+				<currency-iso-code>USD</currency-iso-code>
+				<sub-merchant-account type="boolean">false</sub-merchant-account>
+				<status>active</status>
+			</merchant-account>
+			<amount>100.00</amount>
+			<disbursement-date type="date">2014-02-10</disbursement-date>
+			<exception-message>bank_rejected</exception-message>
+			<follow-up-action>update_funding_information</follow-up-action>
+		</disbursement>
+	`,
+	)
+}
+
+func (g *WebhookTestingGateway) partnerMerchantConnectedXML(id string) string {
+	return `
+	<partner-merchant>
+		<merchant-public-id>public_id</merchant-public-id>
+		<public-key>public_key</public-key>
+		<private-key>private_key</private-key>
+		<partner-merchant-id>abc123</partner-merchant-id>
+		<client-side-encryption-key>cse_key</client-side-encryption-key>
+	</partner-merchant>
+	`
+}
+
+func (g *WebhookTestingGateway) partnerMerchantDisconnectedXML(id string) string {
+	return `
+	<partner-merchant>
+		<partner-merchant-id>abc123</partner-merchant-id>
+	</partner-merchant>
+	`
+}
+
+func (g *WebhookTestingGateway) partnerMerchantDeclinedXML(id string) string {
+	return `
+	<partner-merchant>
+		<partner-merchant-id>abc123</partner-merchant-id>
+	</partner-merchant>
+	`
+}
+
+func (g *WebhookTestingGateway) accountUpdaterDailyReportXML(id string) string {
+	return `
+	<account-updater-daily-report>
+		<report-date type="date">2016-01-14</report-date>
+		<report-url>link-to-csv-report</report-url>
+	</account-updater-daily-report>
+	`
+}
+
+func (g *WebhookTestingGateway) sub(id string, xmlTemplate string) string {
+	var b bytes.Buffer
+	tmpl, err := template.New("").Parse(xmlTemplate)
+	err = tmpl.Execute(&b, struct{ ID string }{ID: id})
+	if err != nil {
+		panic(fmt.Errorf("creating xml template: " + err.Error()))
+	}
+	return b.String()
+}

--- a/webhook_testing_gateway_test.go
+++ b/webhook_testing_gateway_test.go
@@ -1,0 +1,37 @@
+package braintree
+
+import "testing"
+
+func TestWebhookTestingGatewayRequest(t *testing.T) {
+	t.Parallel()
+
+	testingWebhookGateway := testGateway.WebhookTesting()
+	webhookGateway := testGateway.WebhookNotification()
+
+	kind := SubscriptionChargedSuccessfullyWebhook
+	id := "123"
+
+	r, err := testingWebhookGateway.Request(kind, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r.ParseForm()
+	payload := r.FormValue("bt_payload")
+	signature := r.FormValue("bt_signature")
+
+	notification, err := webhookGateway.Parse(signature, payload)
+
+	if err != nil {
+		t.Fatal(err)
+	} else if notification.Kind != SubscriptionChargedSuccessfullyWebhook {
+		t.Fatal("Incorrect Notification kind, expected subscription_charged_successfully got", notification.Kind)
+	} else if notification.Subject.Subscription == nil {
+		t.Log(notification.Subject)
+		t.Fatal("Notification should have a subscription")
+	} else if len(notification.Subject.Subscription.Transactions.Transaction) != 1 {
+		t.Fatal("Incorrect number of subscription transactions, expected 1, got", len(notification.Subject.Subscription.Transactions.Transaction))
+	} else if notification.Subject.Subscription.Transactions.Transaction[0].Id != "123" {
+		t.Fatal("Incorrect transaction ID, expected '123' got", notification.Subject.Subscription.Transactions.Transaction[0].Id)
+	}
+}


### PR DESCRIPTION
I have added a `WebhookTestingGateway` for testing purposes.

This is useful for people who want to write unit/integration tests to verify their application processes braintree webhook notifications correctly.

Example usage would be:

```go
package integration_test

import (
  "testing"
  "net/http/httptest"

  "github.com/lionelbarrow/braintree-go"
)

func TestMyWebhook(t *testing.T) {
  bt := braintree.New(
		braintree.Sandbox,
		"merchaint_id",
		"public_key",
		"private_key",
	)

  r, err := bt.WebhookTesting().Request(
    "POST",
    "http://1.2.3.4/webhook/",
    braintree.SubscriptionChargedSuccessfullyWebhook,
    "123", // id
  )
  if err != nil {
    t.Fatal(err)
  }

  // You can now send the payload and signature to your webhook handler
  // and test your application's busines logic

  w := httptest.NewRecorder()
  router.ServeHTTP(w, r)

  // assertions
}
```