### PR TITLE
Add CVVResponseCode and constants to Transaction.

### DIFF
--- a/cvv_response_code.go
+++ b/cvv_response_code.go
@@ -3,14 +3,22 @@ package braintree
 type CVVResponseCode string
 
 const (
-	CVVMatches      CVVResponseCode = "M" // The CVV provided matches the information on file with the cardholder's bank.
-	CVVDoesNotMatch CVVResponseCode = "N" // The CVV provided does not match the information on file with the cardholder's bank.
+	// The CVV provided matches the information on file with the cardholder's bank.
+	CVVResponseCodeMatches CVVResponseCode = "M"
+
+	// The CVV provided does not match the information on file with the cardholder's bank.
+	CVVResponseCodeDoesNotMatch CVVResponseCode = "N"
 
 	// The card-issuing bank received the CVV but did not verify whether it was correct.
 	// This typically happens if the processor declines an authorization before the bank evaluates the CVV.
-	CVVNotVerified CVVResponseCode = "U"
+	CVVResponseCodeNotVerified CVVResponseCode = "U"
 
-	CVVNotProvided              CVVResponseCode = "I" // No CVV was provided.
-	CVVIssuerDoesNotParticipate CVVResponseCode = "S" // The CVV was provided but the card-issuing bank does not participate in card verification.
-	CVVNotApplicable            CVVResponseCode = "A" // The CVV was provided but this type of transaction does not support card verification.
+	// No CVV was provided.
+	CVVResponseCodeNotProvided CVVResponseCode = "I"
+
+	// The CVV was provided but the card-issuing bank does not participate in card verification.
+	CVVResponseCodeIssuerDoesNotParticipate CVVResponseCode = "S"
+
+	// The CVV was provided but this type of transaction does not support card verification.
+	CVVResponseCodeNotApplicable CVVResponseCode = "A"
 )

--- a/cvv_response_code.go
+++ b/cvv_response_code.go
@@ -1,0 +1,16 @@
+package braintree
+
+type CVVResponseCode string
+
+const (
+	CVVMatches      CVVResponseCode = "M" // The CVV provided matches the information on file with the cardholder's bank.
+	CVVDoesNotMatch CVVResponseCode = "N" // The CVV provided does not match the information on file with the cardholder's bank.
+
+	// The card-issuing bank received the CVV but did not verify whether it was correct.
+	// This typically happens if the processor declines an authorization before the bank evaluates the CVV.
+	CVVNotVerified CVVResponseCode = "U"
+
+	CVVNotProvided              CVVResponseCode = "I" // No CVV was provided.
+	CVVIssuerDoesNotParticipate CVVResponseCode = "S" // The CVV was provided but the card-issuing bank does not participate in card verification.
+	CVVNotApplicable            CVVResponseCode = "A" // The CVV was provided but this type of transaction does not support card verification.
+)

--- a/transaction.go
+++ b/transaction.go
@@ -43,6 +43,7 @@ type Transaction struct {
 	Descriptor                  *Descriptor               `xml:"descriptor,omitempty"`
 	CustomFields                customfields.CustomFields `xml:"custom-fields,omitempty"`
 	GatewayRejectionReason      GatewayRejectionReason    `xml:"gateway-rejection-reason,omitempty"`
+	CVVResponseCode             CVVResponseCode           `xml:"cvv-response-code,omitempty"`
 }
 
 type TransactionRequest struct {
@@ -73,7 +74,6 @@ type TransactionRequest struct {
 //   <avs-error-response-code nil="true"></avs-error-response-code>
 //   <avs-postal-code-response-code>I</avs-postal-code-response-code>
 //   <avs-street-address-response-code>I</avs-street-address-response-code>
-//   <cvv-response-code>I</cvv-response-code>
 //   <voice-referral-number nil="true"></voice-referral-number>
 //   <purchase-order-number nil="true"></purchase-order-number>
 //   <tax-amount nil="true"></tax-amount>

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -231,18 +231,13 @@ func TestTransactionCreateWhenGatewayRejectedFraud(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	txnID := err.(*BraintreeError).Transaction.Id
-	txn, err := testGateway.Transaction().Find(txnID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	txn := err.(*BraintreeError).Transaction
 	if txn.Status != "gateway_rejected" {
 		t.Fatalf("Got status %q, want %q", txn.Status, "gateway_rejected")
 	}
 
 	if txn.GatewayRejectionReason != GatewayRejectionReasonFraud {
-		t.Fatalf("Got gateway rejection reason %q, wanted 'fraud'", txn.GatewayRejectionReason)
+		t.Fatalf("Got gateway rejection reason %q, wanted %q", txn.GatewayRejectionReason, GatewayRejectionReasonFraud)
 	}
 
 	if txn.ProcessorResponseCode != 0 {
@@ -267,11 +262,7 @@ func TestTransactionCreatedWhenCVVDoesNotMatch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	txnID := err.(*BraintreeError).Transaction.Id
-	txn, err := testGateway.Transaction().Find(txnID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	txn := err.(*BraintreeError).Transaction
 
 	if txn.Status != "gateway_rejected" {
 		t.Fatalf("Got status %q, want %q", txn.Status, "gateway_rejected")

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -277,12 +277,12 @@ func TestTransactionCreatedWhenCVVDoesNotMatch(t *testing.T) {
 		t.Fatalf("Got status %q, want %q", txn.Status, "gateway_rejected")
 	}
 
-	if txn.GatewayRejectionReason != "cvv" {
-		t.Fatalf("Got gateway rejection reason '%s', wanted 'cvv'", txn.GatewayRejectionReason)
+	if txn.GatewayRejectionReason != GatewayRejectionReasonCVV {
+		t.Fatalf("Got gateway rejection reason %q, wanted %q", txn.GatewayRejectionReason, GatewayRejectionReasonCVV)
 	}
 
-	if txn.CVVResponseCode != CVVDoesNotMatch {
-		t.Fatalf("Got CVV Response Code '%s', wanted 'N'", txn.CVVResponseCode)
+	if txn.CVVResponseCode != CVVResponseCodeDoesNotMatch {
+		t.Fatalf("Got CVV Response Code %q, wanted %q", txn.CVVResponseCode, CVVResponseCodeDoesNotMatch)
 	}
 }
 


### PR DESCRIPTION
I wasn't sure whether we wanted constants in this one-- I'm happy to pull them out, since they're not in the Java implementation. Also, unsure stylistically about the multiline comment in the constant file, but here's a draft. Feedback welcome.