### PR TITLE
Added SubscriptionId field to Transaction.

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -20,6 +20,7 @@ type Transaction struct {
 	PaymentMethodNonce           string                    `xml:"payment-method-nonce,omitempty"`
 	MerchantAccountId            string                    `xml:"merchant-account-id,omitempty"`
 	PlanId                       string                    `xml:"plan-id,omitempty"`
+	SubscriptionId               string                    `xml:"subscription-id,omitempty"`
 	CreditCard                   *CreditCard               `xml:"credit-card,omitempty"`
 	Customer                     *Customer                 `xml:"customer,omitempty"`
 	BillingAddress               *Address                  `xml:"billing,omitempty"`


### PR DESCRIPTION
This PR request adds `SubscriptionId` field to `Transaction` object.

This is part of XML object together with `PlanID` when transaction is part of a subscription, e.g.:

```xml
          <plan-id>GBP_interval_1_month</plan-id>
          <subscription-id>dyvvpb</subscription-id>
``` 

It is useful to have access to this field when processing webhooks so you can easily tell which subscription this new transaction belongs to.