### PR TITLE
Remove CustomerID field from Transaction

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -10,7 +10,6 @@ import (
 type Transaction struct {
 	XMLName                      string                    `xml:"transaction"`
 	Id                           string                    `xml:"id,omitempty"`
-	CustomerID                   string                    `xml:"customer-id,omitempty"`
 	Status                       string                    `xml:"status,omitempty"`
 	Type                         string                    `xml:"type,omitempty"`
 	CurrencyISOCode              string                    `xml:"currency-iso-code,omitempty"`


### PR DESCRIPTION
What
===
Remove `CustomerID` field from `Transaction`.

Why
===
The field is not returned in a transaction response and only exists in
the transaction request. It is an artifact of when the `Transaction`
struct was used for both requests and responses.  The field also exists
on the `TransactionRequest` struct where it should exist, but it doesn't
need to exist on `Transaction.

Ref
===
Resolves #150.