### PR TITLE
Add CHANGELOG for v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
-## 0.10.0 (April 14th, 2016)
+## 0.11.0 (May 12th, 2017)
+
+BACKWARDS INCOMPATIBILITES:
+
+* `TransactionGateway` `Create` now takes a `TransactionRequest`. Fields were removed from `Transaction` that are not included in the response.
+
+IMPROVEMENTS:
+
+* `CurrencyISOCode` added to `Transaction`.
+* `GatewayRejectionReason` added to `Transaction`.
+* `CVVResponseCode` added to `Transaction`.
+* `AVSErrorResponseCode`, `AVSPostalCodeResponseCode` and `AVSStreetAddressResponseCode` added to `Transaction`.
+* `SubscriptionId` added to `Transaction`.
+* `RiskDataRequest` added and can be set on `TransactionRequest` when calling `TransactionGateway` `Create`.
+* `WebhookNotificationGateway` now supports validating signatures on webhook payloads for accounts that have multiple API Keys.
+* `ParseRequest` added to `WebhookNotificationGateway`.
+* `WebhookTestingGateway` added for generating sample webhook notifications.
+
+## 0.10.0 (April 14th, 2017)
 
 BACKWARDS INCOMPATIBILITES:
 

--- a/braintree.go
+++ b/braintree.go
@@ -9,8 +9,6 @@ import (
 	"net/http"
 )
 
-const LibraryVersion = "0.10.0"
-
 type apiVersion int
 
 const (

--- a/version.go
+++ b/version.go
@@ -1,0 +1,3 @@
+package braintree
+
+const LibraryVersion = "0.11.0"


### PR DESCRIPTION
@lionelbarrow @jszwedko and anyone else, are we good to cut `v0.11.0` with what we've got below? I can cut the release tomorrow if I get a 👍 .

The issues and PRs resolved in `v0.11.0` can be seen at:
https://github.com/lionelbarrow/braintree-go/milestone/1?closed=1