### PR TITLE
Add errcheck static analysis for CI runs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,23 @@
 language: go
-go:
-  - 1.2
-  - 1.3
-  - 1.4
-  - 1.5
-  - 1.6
-  - 1.7
-  - 1.8
-  - tip
+matrix:
+  include:
+  - go: 1.2
+  - go: 1.3
+  - go: 1.4
+  - go: 1.5
+  - go: 1.6
+  - go: 1.7
+  - go: 1.8
+    env: ERRCHECK=true
+  - go: tip
 
 go_import_path: github.com/lionelbarrow/braintree-go
+
+install:
+  - if [ -n "$ERRCHECK" ] ; then go get -u github.com/kisielk/errcheck ; fi
 
 script:
   - source .default.env
   - go vet ./...
+  - if [ -n "$ERRCHECK" ] ; then CGO_ENABLED=0 errcheck ./... ; else echo "Skipping errcheck" ; fi
   - go test -parallel 15 -v ./...

--- a/braintree.go
+++ b/braintree.go
@@ -101,7 +101,7 @@ func (g *Braintree) executeVersion(method, path string, xmlObj interface{}, v ap
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	btr := &Response{
 		Response: resp,

--- a/customfields/custom_fields.go
+++ b/customfields/custom_fields.go
@@ -33,10 +33,13 @@ func (c CustomFields) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 	for k, v := range c {
 		tag := nameMarshalReplacer.Replace(k)
-		e.Encode(xmlField{
+		err := e.Encode(xmlField{
 			XMLName: xml.Name{Local: tag},
 			Value:   v,
 		})
+		if err != nil {
+			return err
+		}
 	}
 
 	return e.EncodeToken(start.End())

--- a/date/date.go
+++ b/date/date.go
@@ -15,7 +15,10 @@ type Date struct {
 // e.g. "2014-02-09"
 func (d *Date) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	var v string
-	dec.DecodeElement(&v, &start)
+	err := dec.DecodeElement(&v, &start)
+	if err != nil {
+		return err
+	}
 
 	parse, err := time.Parse("2006-01-02", v)
 	if err != nil {

--- a/examples/subscription/server.go
+++ b/examples/subscription/server.go
@@ -88,8 +88,14 @@ func main() {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(fmt.Sprintf("Success! Subscription #%s created with user ID %s", subscription.Id, customer.Id)))
+		_, err = w.Write([]byte(fmt.Sprintf("Success! Subscription #%s created with user ID %s", subscription.Id, customer.Id)))
+		if err != nil {
+			log.Fatal(err)
+		}
 	})
 
-	http.ListenAndServe(":8080", nil)
+	err := http.ListenAndServe(":8080", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/examples/transaction/server.go
+++ b/examples/transaction/server.go
@@ -18,6 +18,7 @@ package main
 import (
 	"fmt"
 	"html/template"
+	"log"
 	"net/http"
 	"os"
 
@@ -31,7 +32,10 @@ type BraintreeJS struct {
 func showForm(w http.ResponseWriter, r *http.Request) {
 	config := BraintreeJS{Key: "'" + template.HTML(os.Getenv("BRAINTREE_CSE_KEY")) + "'"}
 	t := template.Must(template.ParseFiles("form.html"))
-	t.Execute(w, config)
+	err := t.Execute(w, config)
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+	}
 }
 
 func createTransaction(w http.ResponseWriter, r *http.Request) {
@@ -65,5 +69,8 @@ func createTransaction(w http.ResponseWriter, r *http.Request) {
 func main() {
 	http.HandleFunc("/", showForm)
 	http.HandleFunc("/create_transaction", createTransaction)
-	http.ListenAndServe(":8080", nil)
+	err := http.ListenAndServe(":8080", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/response.go
+++ b/response.go
@@ -127,7 +127,7 @@ func (r *Response) unpackBody() error {
 		if err != nil {
 			return err
 		}
-		defer r.Response.Body.Close()
+		defer func() { _ = r.Response.Body.Close() }()
 
 		buf, err := ioutil.ReadAll(b)
 		if err != nil {
@@ -140,8 +140,8 @@ func (r *Response) unpackBody() error {
 
 func (r *Response) apiError() error {
 	var b BraintreeError
-	xml.Unmarshal(r.Body, &b)
-	if b.ErrorMessage != "" {
+	err := xml.Unmarshal(r.Body, &b)
+	if err == nil && b.ErrorMessage != "" {
 		b.statusCode = r.StatusCode
 		return &b
 	}

--- a/testhelpers/random.go
+++ b/testhelpers/random.go
@@ -10,9 +10,15 @@ import (
 func RandomInt() int64 {
 	var n int64
 	b := make([]byte, 8)
-	rand.Read(b)
+	_, err := rand.Read(b)
+	if err != nil {
+		panic(err)
+	}
 	buf := bytes.NewBuffer(b)
-	binary.Read(buf, binary.LittleEndian, &n)
+	err = binary.Read(buf, binary.LittleEndian, &n)
+	if err != nil {
+		panic(err)
+	}
 	return n
 }
 

--- a/webhook_testing_gateway_test.go
+++ b/webhook_testing_gateway_test.go
@@ -16,7 +16,10 @@ func TestWebhookTestingGatewayRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r.ParseForm()
+	err = r.ParseForm()
+	if err != nil {
+		t.Fatal(err)
+	}
 	payload := r.FormValue("bt_payload")
 	signature := r.FormValue("bt_signature")
 


### PR DESCRIPTION
What
===
Add errcheck static analysis for CI runs.

Why
===
Not handling errors will mean we'll write code where errors are silently
ignored. The errcheck tool checks that all functions that return errors
collect the error to do something with it or check that the error is
intentionally ignored.

Why only on CI
===
errcheck is not very fast and can take a couple seconds to run. Running
it on CI only should strike a balance where missed errors can be caugt
before changes are accepted but errchecks slowness won't impact
iterating quickly.