### PR TITLE
Transaction Status Constants

### DIFF
--- a/merchant_account_integration_test.go
+++ b/merchant_account_integration_test.go
@@ -92,7 +92,7 @@ func TestMerchantAccountTransaction(t *testing.T) {
 	if tx.Id == "" {
 		t.Fatal("Received invalid ID on new transaction")
 	}
-	if tx.Status != "authorized" {
+	if tx.Status != TransactionStatusAuthorized {
 		t.Fatal(tx.Status)
 	}
 }

--- a/search_test.go
+++ b/search_test.go
@@ -61,9 +61,9 @@ func TestSearchXMLEncode(t *testing.T) {
 
 	f14 := s.AddMultiField("status")
 	f14.Items = []string{
-		"authorized",
-		"submitted_for_settlement",
-		"settled",
+		string(TransactionStatusAuthorized),
+		string(TransactionStatusSubmittedForSettlement),
+		string(TransactionStatusSettled),
 	}
 
 	b, err := xml.MarshalIndent(s, "", "  ")

--- a/settlement_integration_test.go
+++ b/settlement_integration_test.go
@@ -18,7 +18,7 @@ func TestSettlementBatch(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Logf("transaction : %s : %s : %s : %s\n", tx.MerchantAccountId, tx.Id, tx.CreditCard.CardType, tx.Status)
-	if tx.Status != "authorized" {
+	if tx.Status != TransactionStatusAuthorized {
 		t.Fatal(tx.Status)
 	}
 
@@ -28,7 +28,7 @@ func TestSettlementBatch(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Logf("transaction : %s : %s : %s : %s\n", tx.MerchantAccountId, tx.Id, tx.CreditCard.CardType, tx.Status)
-	if x := tx.Status; x != "submitted_for_settlement" {
+	if x := tx.Status; x != TransactionStatusSubmittedForSettlement {
 		t.Fatal(x)
 	}
 
@@ -38,7 +38,7 @@ func TestSettlementBatch(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Logf("transaction : %s : %s : %s : %s\n", tx.MerchantAccountId, tx.Id, tx.CreditCard.CardType, tx.Status)
-	if x := tx.Status; x != "settled" {
+	if x := tx.Status; x != TransactionStatusSettled {
 		t.Fatal(x)
 	}
 

--- a/testing_gateway.go
+++ b/testing_gateway.go
@@ -22,12 +22,12 @@ func (g *TestingGateway) SettlementDecline(transactionID string) (*Transaction, 
 
 // SettlementPending changes the transaction's status to settlement_pending.
 func (g *TestingGateway) SettlementPending(transactionID string) (*Transaction, error) {
-	return g.setStatus(transactionID, "settlement_pending")
+	return g.setStatus(transactionID, TransactionStatusSettlementPending)
 }
 
-func (g *TestingGateway) setStatus(transactionID, status string) (*Transaction, error) {
+func (g *TestingGateway) setStatus(transactionID string, status TransactionStatus) (*Transaction, error) {
 	if g.Environment() != Production {
-		resp, err := g.execute("PUT", "transactions/"+transactionID+"/"+status, nil)
+		resp, err := g.execute("PUT", "transactions/"+transactionID+"/"+string(status), nil)
 		if err != nil {
 			return nil, err
 		}

--- a/testing_integration_test.go
+++ b/testing_integration_test.go
@@ -35,7 +35,7 @@ func TestSettleTransaction(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if txn.Status != "settled" {
+	if txn.Status != TransactionStatusSettled {
 		t.Fatal(txn.Status)
 	}
 }
@@ -71,7 +71,7 @@ func TestSettlementConfirmTransaction(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if txn.Status != "settlement_confirmed" {
+	if txn.Status != TransactionStatusSettlementConfirmed {
 		t.Fatal(txn.Status)
 	}
 }
@@ -107,7 +107,7 @@ func TestSettlementDeclinedTransaction(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if txn.Status != "settlement_declined" {
+	if txn.Status != TransactionStatusSettlementDeclined {
 		t.Fatal(txn.Status)
 	}
 }
@@ -143,7 +143,7 @@ func TestSettlementPendingTransaction(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if txn.Status != "settlement_pending" {
+	if txn.Status != TransactionStatusSettlementPending {
 		t.Fatal(txn.Status)
 	}
 }
@@ -183,7 +183,7 @@ func TestTransactionCreateSettleCheckCreditCardDetails(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if txn.Status != "settled" {
+	if txn.Status != TransactionStatusSettled {
 		t.Fatal(txn.Status)
 	}
 }

--- a/transaction.go
+++ b/transaction.go
@@ -7,27 +7,29 @@ import (
 	"github.com/lionelbarrow/braintree-go/nullable"
 )
 
+type TransactionStatus string
+
 const (
-	TransactionStatusAuthorizationExpired   = "authorization_expired"
-	TransactionStatusAuthorizing            = "authorizing"
-	TransactionStatusAuthorized             = "authorized"
-	TransactionStatusGatewayRejected        = "gateway_rejected"
-	TransactionStatusFailed                 = "failed"
-	TransactionStatusProcessorDeclined      = "processor_declined"
-	TransactionStatusSettled                = "settled"
-	TransactionStatusSettlementConfirmed    = "settlement_confirmed"
-	TransactionStatusSettlementDeclined     = "settlement_declined"
-	TransactionStatusSettlementPending      = "settlement_pending"
-	TransactionStatusSettling               = "settling"
-	TransactionStatusSubmittedForSettlement = "submitted_for_settlement"
-	TransactionStatusVoided                 = "voided"
-	TransactionStatusUnrecognized           = "unrecognized"
+	TransactionStatusAuthorizationExpired   TransactionStatus = "authorization_expired"
+	TransactionStatusAuthorizing            TransactionStatus = "authorizing"
+	TransactionStatusAuthorized             TransactionStatus = "authorized"
+	TransactionStatusGatewayRejected        TransactionStatus = "gateway_rejected"
+	TransactionStatusFailed                 TransactionStatus = "failed"
+	TransactionStatusProcessorDeclined      TransactionStatus = "processor_declined"
+	TransactionStatusSettled                TransactionStatus = "settled"
+	TransactionStatusSettlementConfirmed    TransactionStatus = "settlement_confirmed"
+	TransactionStatusSettlementDeclined     TransactionStatus = "settlement_declined"
+	TransactionStatusSettlementPending      TransactionStatus = "settlement_pending"
+	TransactionStatusSettling               TransactionStatus = "settling"
+	TransactionStatusSubmittedForSettlement TransactionStatus = "submitted_for_settlement"
+	TransactionStatusVoided                 TransactionStatus = "voided"
+	TransactionStatusUnrecognized           TransactionStatus = "unrecognized"
 )
 
 type Transaction struct {
 	XMLName                      string                    `xml:"transaction"`
 	Id                           string                    `xml:"id,omitempty"`
-	Status                       string                    `xml:"status,omitempty"`
+	Status                       TransactionStatus         `xml:"status,omitempty"`
 	Type                         string                    `xml:"type,omitempty"`
 	CurrencyISOCode              string                    `xml:"currency-iso-code,omitempty"`
 	Amount                       *Decimal                  `xml:"amount"`

--- a/transaction.go
+++ b/transaction.go
@@ -7,6 +7,23 @@ import (
 	"github.com/lionelbarrow/braintree-go/nullable"
 )
 
+const (
+	TransactionStatusAuthorizationExpired   = "authorization_expired"
+	TransactionStatusAuthorizing            = "authorizing"
+	TransactionStatusAuthorized             = "authorized"
+	TransactionStatusGatewayRejected        = "gateway_rejected"
+	TransactionStatusFailed                 = "failed"
+	TransactionStatusProcessorDeclined      = "processor_declined"
+	TransactionStatusSettled                = "settled"
+	TransactionStatusSettlementConfirmed    = "settlement_confirmed"
+	TransactionStatusSettlementDeclined     = "settlement_declined"
+	TransactionStatusSettlementPending      = "settlement_pending"
+	TransactionStatusSettling               = "settling"
+	TransactionStatusSubmittedForSettlement = "submitted_for_settlement"
+	TransactionStatusVoided                 = "voided"
+	TransactionStatusUnrecognized           = "unrecognized"
+)
+
 type Transaction struct {
 	XMLName                      string                    `xml:"transaction"`
 	Id                           string                    `xml:"id,omitempty"`

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -34,7 +34,7 @@ func TestTransactionCreateSubmitForSettlementAndVoid(t *testing.T) {
 	if tx.Id == "" {
 		t.Fatal("Received invalid ID on new transaction")
 	}
-	if tx.Status != "authorized" {
+	if tx.Status != TransactionStatusAuthorized {
 		t.Fatal(tx.Status)
 	}
 
@@ -47,7 +47,7 @@ func TestTransactionCreateSubmitForSettlementAndVoid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if x := tx2.Status; x != "submitted_for_settlement" {
+	if x := tx2.Status; x != TransactionStatusSubmittedForSettlement {
 		t.Fatal(x)
 	}
 	if amount := tx2.Amount; amount.Cmp(ten) != 0 {
@@ -62,7 +62,7 @@ func TestTransactionCreateSubmitForSettlementAndVoid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if x := tx3.Status; x != "voided" {
+	if x := tx3.Status; x != TransactionStatusVoided {
 		t.Fatal(x)
 	}
 }
@@ -232,8 +232,8 @@ func TestTransactionCreateWhenGatewayRejectedFraud(t *testing.T) {
 	}
 
 	txn := err.(*BraintreeError).Transaction
-	if txn.Status != "gateway_rejected" {
-		t.Fatalf("Got status %q, want %q", txn.Status, "gateway_rejected")
+	if txn.Status != TransactionStatusGatewayRejected {
+		t.Fatalf("Got status %q, want %q", txn.Status, TransactionStatusGatewayRejected)
 	}
 
 	if txn.GatewayRejectionReason != GatewayRejectionReasonFraud {
@@ -264,8 +264,8 @@ func TestTransactionCreatedWhenCVVDoesNotMatch(t *testing.T) {
 
 	txn := err.(*BraintreeError).Transaction
 
-	if txn.Status != "gateway_rejected" {
-		t.Fatalf("Got status %q, want %q", txn.Status, "gateway_rejected")
+	if txn.Status != TransactionStatusGatewayRejected {
+		t.Fatalf("Got status %q, want %q", txn.Status, TransactionStatusGatewayRejected)
 	}
 
 	if txn.GatewayRejectionReason != GatewayRejectionReasonCVV {
@@ -307,8 +307,8 @@ func TestTransactionCreatedWhenAVSBankDoesNotSupport(t *testing.T) {
 
 	txn := err.(*BraintreeError).Transaction
 
-	if txn.Status != "gateway_rejected" {
-		t.Fatalf("Got status %q, want %q", txn.Status, "gateway_rejected")
+	if txn.Status != TransactionStatusGatewayRejected {
+		t.Fatalf("Got status %q, want %q", txn.Status, TransactionStatusGatewayRejected)
 	}
 
 	if txn.GatewayRejectionReason != GatewayRejectionReasonAVS {
@@ -350,8 +350,8 @@ func TestTransactionCreatedWhenAVSPostalDoesNotMatch(t *testing.T) {
 
 	txn := err.(*BraintreeError).Transaction
 
-	if txn.Status != "gateway_rejected" {
-		t.Fatalf("Got status %q, want %q", txn.Status, "gateway_rejected")
+	if txn.Status != TransactionStatusGatewayRejected {
+		t.Fatalf("Got status %q, want %q", txn.Status, TransactionStatusGatewayRejected)
 	}
 
 	if txn.GatewayRejectionReason != GatewayRejectionReasonAVS {
@@ -393,8 +393,8 @@ func TestTransactionCreatedWhenAVStreetAddressDoesNotMatch(t *testing.T) {
 
 	txn := err.(*BraintreeError).Transaction
 
-	if txn.Status != "gateway_rejected" {
-		t.Fatalf("Got status %q, want %q", txn.Status, "gateway_rejected")
+	if txn.Status != TransactionStatusGatewayRejected {
+		t.Fatalf("Got status %q, want %q", txn.Status, TransactionStatusGatewayRejected)
 	}
 
 	if txn.GatewayRejectionReason != GatewayRejectionReasonAVS {
@@ -475,8 +475,8 @@ func TestTransactionDescriptorFields(t *testing.T) {
 	if tx2.Amount.Cmp(tx.Amount) != 0 {
 		t.Fatalf("expected Amount to be equal, but %s was not %s", tx2.Amount, tx.Amount)
 	}
-	if tx2.Status != "submitted_for_settlement" {
-		t.Fatalf("expected tx2.Status to be %s, but got %s", "submitted_for_settlement", tx2.Status)
+	if tx2.Status != TransactionStatusSubmittedForSettlement {
+		t.Fatalf("expected tx2.Status to be %s, but got %s", TransactionStatusSubmittedForSettlement, tx2.Status)
 	}
 	if tx2.Descriptor.Name != "Company Name*Product 1" {
 		t.Fatalf("expected tx2.Descriptor.Name to be Company Name*Product 1, but got %s", tx2.Descriptor.Name)
@@ -601,8 +601,8 @@ func TestAllTransactionFields(t *testing.T) {
 	if tx2.Customer.Id == "" {
 		t.Fatalf("expected Customer.Id to be equal, but %s was not %s", tx2.Customer.Id, tx.Customer.Id)
 	}
-	if tx2.Status != "submitted_for_settlement" {
-		t.Fatalf("expected tx2.Status to be %s, but got %s", "submitted_for_settlement", tx2.Status)
+	if tx2.Status != TransactionStatusSubmittedForSettlement {
+		t.Fatalf("expected tx2.Status to be %s, but got %s", TransactionStatusSubmittedForSettlement, tx2.Status)
 	}
 	if tx2.PaymentInstrumentType != "credit_card" {
 		t.Fatalf("expected tx2.PaymentInstrumentType to be %s, but got %s", "credit_card", tx2.PaymentInstrumentType)
@@ -725,7 +725,7 @@ func TestTransactionCreateSettleAndFullRefund(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if txn.Status != "settled" {
+	if txn.Status != TransactionStatusSettled {
 		t.Fatal(txn.Status)
 	}
 
@@ -737,7 +737,7 @@ func TestTransactionCreateSettleAndFullRefund(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if x := refundTxn.Status; x != "submitted_for_settlement" {
+	if x := refundTxn.Status; x != TransactionStatusSubmittedForSettlement {
 		t.Fatal(x)
 	}
 
@@ -746,7 +746,7 @@ func TestTransactionCreateSettleAndFullRefund(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if refundTxn.Status != "settled" {
+	if refundTxn.Status != TransactionStatusSettled {
 		t.Fatal(txn.Status)
 	}
 
@@ -801,7 +801,7 @@ func TestTransactionCreateSettleAndPartialRefund(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if txn.Status != "settled" {
+	if txn.Status != TransactionStatusSettled {
 		t.Fatal(txn.Status)
 	}
 
@@ -813,7 +813,7 @@ func TestTransactionCreateSettleAndPartialRefund(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if x := refundTxn.Status; x != "submitted_for_settlement" {
+	if x := refundTxn.Status; x != TransactionStatusSubmittedForSettlement {
 		t.Fatal(x)
 	}
 
@@ -822,7 +822,7 @@ func TestTransactionCreateSettleAndPartialRefund(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if refundTxn.Status != "settled" {
+	if refundTxn.Status != TransactionStatusSettled {
 		t.Fatal(txn.Status)
 	}
 

--- a/transaction_paypal_details_integration_test.go
+++ b/transaction_paypal_details_integration_test.go
@@ -17,7 +17,7 @@ func TestTransactionPayPalDetails(t *testing.T) {
 	if tx.Id == "" {
 		t.Fatal("Received invalid ID on new transaction")
 	}
-	if tx.Status != "authorized" {
+	if tx.Status != TransactionStatusAuthorized {
 		t.Fatal(tx.Status)
 	}
 
@@ -71,7 +71,7 @@ func TestTransactionWithoutPayPalDetails(t *testing.T) {
 	if tx.Id == "" {
 		t.Fatal("Received invalid ID on new transaction")
 	}
-	if tx.Status != "authorized" {
+	if tx.Status != TransactionStatusAuthorized {
 		t.Fatal(tx.Status)
 	}
 


### PR DESCRIPTION
Added constants for transaction states so they can be referred from code using this library.

This is very useful when integrating with Braintree in application code and we need to check transaction status and execute some logic based on different states.

It is much better to refer to constants in this library than to compare with strings. Less room for error as states are defined in one place.

Values taken from Ruby lib: https://github.com/braintree/braintree_ruby/blob/master/lib/braintree/transaction.rb#L32