### PR TITLE
Remove support for go1.2-1.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: go
 matrix:
   include:
-  - go: 1.2
-  - go: 1.3
-  - go: 1.4
-  - go: 1.5
   - go: 1.6
   - go: 1.7
   - go: 1.8

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ In addition to creating transactions, you can also tokenize credit card informat
 
 The usual. `go get github.com/lionelbarrow/braintree-go`
 
+### Supported Go Versions
+
+* 1.6
+* 1.7
+* 1.8
+
 ### Documentation
 
 Braintree provides a [ton of documentation](https://www.braintreepayments.com/docs/ruby/guide/overview) on how to use their API. I recommend you use the Ruby documentation when following along, as the Ruby client library is broadly similar to this one.


### PR DESCRIPTION
What
===
Remove support for go1.2-1.5 leaving support for go1.6+.

Why
===
Supporting older versions is becoming a significant constraint. Given
that all go versions have a go1 compatibility promise and go1.6 is
one year old, it's reasonable to expect newer versions. This will make
it easier to support new features like context (#156) and default
timeouts (#133).

Ref
===
There is discussion in #158 that led to the decision to update the
compatible versions.