### PR TITLE
Replace PayPal future payments with billing agreements in tests

### DIFF
--- a/customer_integration_test.go
+++ b/customer_integration_test.go
@@ -194,7 +194,7 @@ func TestCustomerPaymentMethods(t *testing.T) {
 
 	paymentMethod1, err := testGateway.PaymentMethod().Create(&PaymentMethodRequest{
 		CustomerId:         customer.Id,
-		PaymentMethodNonce: FakeNoncePayPalFuturePayment,
+		PaymentMethodNonce: FakeNoncePayPalBillingAgreement,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -239,7 +239,7 @@ func TestCustomerDefaultPaymentMethod(t *testing.T) {
 	}
 	_, err = testGateway.PaymentMethod().Create(&PaymentMethodRequest{
 		CustomerId:         customer.Id,
-		PaymentMethodNonce: FakeNoncePayPalFuturePayment,
+		PaymentMethodNonce: FakeNoncePayPalBillingAgreement,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -272,7 +272,7 @@ func TestCustomerDefaultPaymentMethodManuallySet(t *testing.T) {
 	}
 	paymentMethod2, err := testGateway.PaymentMethod().Create(&PaymentMethodRequest{
 		CustomerId:         customer.Id,
-		PaymentMethodNonce: FakeNoncePayPalFuturePayment,
+		PaymentMethodNonce: FakeNoncePayPalBillingAgreement,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/payment_method_integration_test.go
+++ b/payment_method_integration_test.go
@@ -49,7 +49,7 @@ func TestPaymentMethod(t *testing.T) {
 	}
 
 	// Updating with different payment method type should fail
-	if _, err = g.Update(token, &PaymentMethodRequest{PaymentMethodNonce: FakeNoncePayPalFuturePayment}); err == nil {
+	if _, err = g.Update(token, &PaymentMethodRequest{PaymentMethodNonce: FakeNoncePayPalBillingAgreement}); err == nil {
 		t.Errorf("Updating with a different payment method type should have failed")
 	}
 
@@ -74,7 +74,7 @@ func TestPaymentMethod(t *testing.T) {
 	// Create using PayPal
 	paymentMethod, err = g.Create(&PaymentMethodRequest{
 		CustomerId:         cust.Id,
-		PaymentMethodNonce: FakeNoncePayPalFuturePayment,
+		PaymentMethodNonce: FakeNoncePayPalBillingAgreement,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/paypal_account_integration_test.go
+++ b/paypal_account_integration_test.go
@@ -10,7 +10,7 @@ func TestPayPalAccount(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	nonce := FakeNoncePayPalFuturePayment
+	nonce := FakeNoncePayPalBillingAgreement
 
 	g := testGateway.PayPalAccount()
 	paymentMethod, err := testGateway.PaymentMethod().Create(&PaymentMethodRequest{


### PR DESCRIPTION
What
===
Replace PayPal future payments with billing agreements in tests.

Why
===
In the Braintree developers documentation next to the future payments
nonce it says that it is for the deprecated version of the Vault flow
and to use the billing agreement instead.