### PR TITLE
Move Customer PayPal tests into own file

### DIFF
--- a/customer_integration_test.go
+++ b/customer_integration_test.go
@@ -152,38 +152,6 @@ func TestCustomerWithCustomFields(t *testing.T) {
 	}
 }
 
-func TestCustomerPayPalAccount(t *testing.T) {
-	t.Parallel()
-
-	customer, err := testGateway.Customer().Create(&Customer{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	nonce := FakeNoncePayPalFuturePayment
-
-	paymentMethod, err := testGateway.PaymentMethod().Create(&PaymentMethodRequest{
-		CustomerId:         customer.Id,
-		PaymentMethodNonce: nonce,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	paypalAccount := paymentMethod.(*PayPalAccount)
-
-	customerFound, err := testGateway.Customer().Find(customer.Id)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if customerFound.PayPalAccounts == nil || len(customerFound.PayPalAccounts.PayPalAccount) != 1 {
-		t.Fatalf("Customer %#v expected to have one PayPalAccount", customerFound)
-	}
-	if !reflect.DeepEqual(customerFound.PayPalAccounts.PayPalAccount[0], paypalAccount) {
-		t.Fatalf("Got Customer %#v PayPalAccount %#v, want %#v", customerFound, customerFound.PayPalAccounts.PayPalAccount[0], paypalAccount)
-	}
-}
-
 func TestCustomerPaymentMethods(t *testing.T) {
 	t.Parallel()
 

--- a/customer_paypal_account_integration_test.go
+++ b/customer_paypal_account_integration_test.go
@@ -1,0 +1,38 @@
+package braintree
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCustomerPayPalAccount(t *testing.T) {
+	t.Parallel()
+
+	customer, err := testGateway.Customer().Create(&Customer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nonce := FakeNoncePayPalFuturePayment
+
+	paymentMethod, err := testGateway.PaymentMethod().Create(&PaymentMethodRequest{
+		CustomerId:         customer.Id,
+		PaymentMethodNonce: nonce,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	paypalAccount := paymentMethod.(*PayPalAccount)
+
+	customerFound, err := testGateway.Customer().Find(customer.Id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if customerFound.PayPalAccounts == nil || len(customerFound.PayPalAccounts.PayPalAccount) != 1 {
+		t.Fatalf("Customer %#v expected to have one PayPalAccount", customerFound)
+	}
+	if !reflect.DeepEqual(customerFound.PayPalAccounts.PayPalAccount[0], paypalAccount) {
+		t.Fatalf("Got Customer %#v PayPalAccount %#v, want %#v", customerFound, customerFound.PayPalAccounts.PayPalAccount[0], paypalAccount)
+	}
+}


### PR DESCRIPTION
What
===
Move Customer PayPal tests into own file.

Why
===
As we add more payment methods the customer tests are going to be pretty
big. Lets start keeping tests for each payment method in separate files.
Transaction tests already do this.