### PR TITLE
Add support for ApplePay payment methods

### DIFF
--- a/apple_pay_card.go
+++ b/apple_pay_card.go
@@ -1,0 +1,59 @@
+package braintree
+
+import (
+	"encoding/xml"
+	"time"
+)
+
+type ApplePayCard struct {
+	XMLName               xml.Name       `xml:"apple-pay-card"`
+	Token                 string         `xml:"token,omitempty"`
+	ImageURL              string         `xml:"image-url,omitempty"`
+	CardType              string         `xml:"card-type,omitempty"`
+	PaymentInstrumentName string         `xml:"payment-instrument-name,omitempty"`
+	SourceDescription     string         `xml:"source-description,omitempty"`
+	Last4                 string         `xml:"last-4,omitempty"`
+	ExpirationMonth       string         `xml:"expiration-month,omitempty"`
+	ExpirationYear        string         `xml:"expiration-year,omitempty"`
+	Expired               bool           `xml:"expired,omitempty"`
+	Default               bool           `xml:"default,omitempty"`
+	CustomerId            string         `xml:"customer-id,omitempty"`
+	CreatedAt             *time.Time     `xml:"created-at,omitempty"`
+	UpdatedAt             *time.Time     `xml:"updated-at,omitempty"`
+	Subscriptions         *Subscriptions `xml:"subscriptions,omitempty"`
+}
+
+type ApplePayCards struct {
+	ApplePayCard []*ApplePayCard `xml:"apple-pay-card"`
+}
+
+func (a *ApplePayCard) GetCustomerId() string {
+	return a.CustomerId
+}
+
+func (a *ApplePayCard) GetToken() string {
+	return a.Token
+}
+
+func (a *ApplePayCard) IsDefault() bool {
+	return a.Default
+}
+
+func (a *ApplePayCard) GetImageURL() string {
+	return a.ImageURL
+}
+
+// AllSubscriptions returns all subscriptions for this paypal account, or nil if none present.
+func (a *ApplePayCard) AllSubscriptions() []*Subscription {
+	if a.Subscriptions != nil {
+		subs := a.Subscriptions.Subscription
+		if len(subs) > 0 {
+			a := make([]*Subscription, 0, len(subs))
+			for _, s := range subs {
+				a = append(a, s)
+			}
+			return a
+		}
+	}
+	return nil
+}

--- a/apple_pay_details.go
+++ b/apple_pay_details.go
@@ -1,0 +1,12 @@
+package braintree
+
+type ApplePayDetails struct {
+	Token                 string `xml:"token,omitempty"`
+	CardType              string `xml:"card-type,omitempty"`
+	PaymentInstrumentName string `xml:"payment-instrument-name,omitempty"`
+	SourceDescription     string `xml:"source-description,omitempty"`
+	CardholderName        string `xml:"cardholder-name,omitempty"`
+	ExpirationMonth       string `xml:"expiration-month,omitempty"`
+	ExpirationYear        string `xml:"expiration-year,omitempty"`
+	Last4                 string `xml:"last-4,omitempty"`
+}

--- a/customer.go
+++ b/customer.go
@@ -19,6 +19,7 @@ type Customer struct {
 	CreditCard         *CreditCard               `xml:"credit-card,omitempty"`
 	CreditCards        *CreditCards              `xml:"credit-cards,omitempty"`
 	PayPalAccounts     *PayPalAccounts           `xml:"paypal-accounts,omitempty"`
+	ApplePayCards      *ApplePayCards            `xml:"apple-pay-cards,omitempty"`
 	PaymentMethodNonce string                    `xml:"payment-method-nonce,omitempty"`
 }
 
@@ -33,6 +34,11 @@ func (c *Customer) PaymentMethods() []PaymentMethod {
 	if c.PayPalAccounts != nil {
 		for _, pp := range c.PayPalAccounts.PayPalAccount {
 			paymentMethods = append(paymentMethods, pp)
+		}
+	}
+	if c.ApplePayCards != nil {
+		for _, a := range c.ApplePayCards.ApplePayCard {
+			paymentMethods = append(paymentMethods, a)
 		}
 	}
 	return paymentMethods
@@ -61,6 +67,13 @@ func (c *Customer) DefaultPaymentMethod() PaymentMethod {
 		for _, pp := range c.PayPalAccounts.PayPalAccount {
 			if pp.IsDefault() {
 				return pp
+			}
+		}
+	}
+	if c.ApplePayCards != nil {
+		for _, a := range c.ApplePayCards.ApplePayCard {
+			if a.IsDefault() {
+				return a
 			}
 		}
 	}

--- a/customer_apple_pay_integration_test.go
+++ b/customer_apple_pay_integration_test.go
@@ -1,0 +1,38 @@
+package braintree
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCustomerApplePayCard(t *testing.T) {
+	t.Parallel()
+
+	customer, err := testGateway.Customer().Create(&Customer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nonce := FakeNonceApplePayVisa
+
+	paymentMethod, err := testGateway.PaymentMethod().Create(&PaymentMethodRequest{
+		CustomerId:         customer.Id,
+		PaymentMethodNonce: nonce,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	applePayCard := paymentMethod.(*ApplePayCard)
+
+	customerFound, err := testGateway.Customer().Find(customer.Id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if customerFound.ApplePayCards == nil || len(customerFound.ApplePayCards.ApplePayCard) != 1 {
+		t.Fatalf("Customer %#v expected to have one ApplePayCard", customerFound)
+	}
+	if !reflect.DeepEqual(customerFound.ApplePayCards.ApplePayCard[0], applePayCard) {
+		t.Fatalf("Got Customer %#v ApplePayCard %#v, want %#v", customerFound, customerFound.ApplePayCards.ApplePayCard[0], applePayCard)
+	}
+}

--- a/response.go
+++ b/response.go
@@ -52,6 +52,8 @@ func (r *Response) paymentMethod() (PaymentMethod, error) {
 		return r.creditCard()
 	case "paypal-account":
 		return r.paypalAccount()
+	case "apple-pay-card":
+		return r.applePayCard()
 	}
 
 	return nil, fmt.Errorf("Unrecognized payment method %#v", entityName)
@@ -67,6 +69,14 @@ func (r *Response) creditCard() (*CreditCard, error) {
 
 func (r *Response) paypalAccount() (*PayPalAccount, error) {
 	var b PayPalAccount
+	if err := xml.Unmarshal(r.Body, &b); err != nil {
+		return nil, err
+	}
+	return &b, nil
+}
+
+func (r *Response) applePayCard() (*ApplePayCard, error) {
+	var b ApplePayCard
 	if err := xml.Unmarshal(r.Body, &b); err != nil {
 		return nil, err
 	}

--- a/transaction.go
+++ b/transaction.go
@@ -57,6 +57,7 @@ type Transaction struct {
 	SettlementBatchId            string                    `xml:"settlement-batch-id,omitempty"`
 	PaymentInstrumentType        string                    `xml:"payment-instrument-type,omitempty"`
 	PayPalDetails                *PayPalDetails            `xml:"paypal,omitempty"`
+	ApplePayDetails              *ApplePayDetails          `xml:"apple-pay,omitempty"`
 	AdditionalProcessorResponse  string                    `xml:"additional-processor-response,omitempty"`
 	RiskData                     *RiskData                 `xml:"risk-data,omitempty"`
 	Descriptor                   *Descriptor               `xml:"descriptor,omitempty"`

--- a/transaction_apple_pay_details_integration_test.go
+++ b/transaction_apple_pay_details_integration_test.go
@@ -1,0 +1,75 @@
+package braintree
+
+import "testing"
+
+func TestTransactionApplePayDetails(t *testing.T) {
+	tx, err := testGateway.Transaction().Create(&TransactionRequest{
+		Type:               "sale",
+		Amount:             NewDecimal(2000, 2),
+		PaymentMethodNonce: FakeNonceApplePayVisa,
+	})
+
+	t.Log(tx)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tx.Id == "" {
+		t.Fatal("Received invalid ID on new transaction")
+	}
+	if tx.Status != TransactionStatusAuthorized {
+		t.Fatal(tx.Status)
+	}
+
+	if tx.ApplePayDetails == nil {
+		t.Fatal("Expected ApplePayDetails for transaction created with ApplePay nonce")
+	}
+
+	t.Log(tx.ApplePayDetails)
+
+	if tx.ApplePayDetails.CardType == "" {
+		t.Fatal("Expected ApplePayDetails to have CardType set")
+	}
+	if tx.ApplePayDetails.PaymentInstrumentName == "" {
+		t.Fatal("Expected ApplePayDetails to have PaymentInstrumentName set")
+	}
+	if tx.ApplePayDetails.SourceDescription == "" {
+		t.Fatal("Expected ApplePayDetails to have SourceDescription set")
+	}
+	if tx.ApplePayDetails.CardholderName == "" {
+		t.Fatal("Expected ApplePayDetails to have CardholderName set")
+	}
+	if tx.ApplePayDetails.ExpirationMonth == "" {
+		t.Fatal("Expected ApplePayDetails to have ExpirationMonth set")
+	}
+	if tx.ApplePayDetails.ExpirationYear == "" {
+		t.Fatal("Expected ApplePayDetails to have ExpirationYear set")
+	}
+	if tx.ApplePayDetails.Last4 == "" {
+		t.Fatal("Expected ApplePayDetails to have Last3 set")
+	}
+}
+
+func TestTransactionWithoutApplePayDetails(t *testing.T) {
+	tx, err := testGateway.Transaction().Create(&TransactionRequest{
+		Type:               "sale",
+		Amount:             NewDecimal(2000, 2),
+		PaymentMethodNonce: FakeNonceTransactable,
+	})
+
+	t.Log(tx)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tx.Id == "" {
+		t.Fatal("Received invalid ID on new transaction")
+	}
+	if tx.Status != TransactionStatusAuthorized {
+		t.Fatal(tx.Status)
+	}
+
+	if tx.ApplePayDetails != nil {
+		t.Fatalf("Expected ApplePayDetails to be nil for transaction created without ApplePay, but was %#v", tx.ApplePayDetails)
+	}
+}


### PR DESCRIPTION
What
===
Add support for ApplePay payment methods.

Why
===
Because it is supported in the official Braintree SDKs.