### PR TITLE
Fix the settlement summary test

### DIFF
--- a/settlement_integration_test.go
+++ b/settlement_integration_test.go
@@ -2,7 +2,6 @@ package braintree
 
 import (
 	"testing"
-	"time"
 )
 
 func TestSettlementBatch(t *testing.T) {
@@ -37,13 +36,14 @@ func TestSettlementBatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("transaction : %s : %s : %s : %s\n", tx.MerchantAccountId, tx.Id, tx.CreditCard.CardType, tx.Status)
+	t.Logf("transaction : %s : %s : %s : %s : %s\n", tx.MerchantAccountId, tx.Id, tx.CreditCard.CardType, tx.Status, tx.SettlementBatchId)
 	if x := tx.Status; x != TransactionStatusSettled {
 		t.Fatal(x)
 	}
 
 	// Generate Settlement Batch Summary which will include new transaction
-	date := time.Now().Format("2006-01-02")
+	date := tx.SettlementBatchId[:10]
+	t.Logf("summary     : %s\n", date)
 	summary, err := testGateway.Settlement().Generate(&Settlement{Date: date})
 	if err != nil {
 		t.Fatalf("unable to get settlement batch: %s", err)


### PR DESCRIPTION
What
===
Removed the code that calculated which settlement batch date the
transaction was supposed to be in, and replaced it with getting the
settlement batch's date from the transactions `settlement_batch_id`
field.

Why
===
Calculating the settlement batch date for the transaction was
unnecessary and unreliable. We were using the wrong timezone, and while
we could change it to use the correct timezone we can instead get the
date of the settlement batch from the settlement batch ID on the
transaction which is more reliable.

Note
===
The official documentation states that the format of the
settlement_batch_id could change at anytime, which could mean the date
would cease to exist within the ID, but the documentation at todays date
explicitly exposes the format as including the date as a prefix so I
think we can deal with changing the test if it does change in the
future.