### PR TITLE
Reduce the many for loops in DefaultPaymentMethod

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -56,25 +56,9 @@ func (c *Customer) DefaultCreditCard() *CreditCard {
 
 // DefaultPaymentMethod returns the default payment method, or nil
 func (c *Customer) DefaultPaymentMethod() PaymentMethod {
-	if c.CreditCards != nil {
-		for _, cc := range c.CreditCards.CreditCard {
-			if cc.IsDefault() {
-				return cc
-			}
-		}
-	}
-	if c.PayPalAccounts != nil {
-		for _, pp := range c.PayPalAccounts.PayPalAccount {
-			if pp.IsDefault() {
-				return pp
-			}
-		}
-	}
-	if c.ApplePayCards != nil {
-		for _, a := range c.ApplePayCards.ApplePayCard {
-			if a.IsDefault() {
-				return a
-			}
+	for _, pm := range c.PaymentMethods() {
+		if pm.IsDefault() {
+			return pm
 		}
 	}
 	return nil


### PR DESCRIPTION
What
===
Reduce the many for loops in `Customer` `DefaultPaymentMethod()` by
getting the full list of `PaymentMethod`s from `Customer`
`PaymentMethods()` and iterating on that instead of iterating on each
payment methods slice separately.

Why
===
As we add payment methods it's one less place we run the risk of
forgetting to add a payment method here and the function not returning
the correct payment method for a customer. There's a small performance
hit to putting all the payment methods in a slice first then iterating
it, but considering this package makes network calls any performance hit
is negligible in comparison to other operations the package performs.

Partially addresses @lionelbarrow's comment in #164.