### PR TITLE
Reduce the many for loops in PaymentMethods

### DIFF
--- a/apple_pay_card.go
+++ b/apple_pay_card.go
@@ -27,6 +27,17 @@ type ApplePayCards struct {
 	ApplePayCard []*ApplePayCard `xml:"apple-pay-card"`
 }
 
+func (a *ApplePayCards) PaymentMethods() []PaymentMethod {
+	if a == nil {
+		return nil
+	}
+	var paymentMethods []PaymentMethod
+	for _, a := range a.ApplePayCard {
+		paymentMethods = append(paymentMethods, a)
+	}
+	return paymentMethods
+}
+
 func (a *ApplePayCard) GetCustomerId() string {
 	return a.CustomerId
 }

--- a/credit_card.go
+++ b/credit_card.go
@@ -45,6 +45,17 @@ type CreditCards struct {
 	CreditCard []*CreditCard `xml:"credit-card"`
 }
 
+func (cards *CreditCards) PaymentMethods() []PaymentMethod {
+	if cards == nil {
+		return nil
+	}
+	var paymentMethods []PaymentMethod
+	for _, cc := range cards.CreditCard {
+		paymentMethods = append(paymentMethods, cc)
+	}
+	return paymentMethods
+}
+
 type CreditCardOptions struct {
 	VerifyCard                    bool   `xml:"verify-card,omitempty"`
 	VenmoSDKSession               string `xml:"venmo-sdk-session,omitempty"`

--- a/customer.go
+++ b/customer.go
@@ -26,21 +26,9 @@ type Customer struct {
 // PaymentMethods returns a slice of all PaymentMethods this customer has
 func (c *Customer) PaymentMethods() []PaymentMethod {
 	var paymentMethods []PaymentMethod
-	if c.CreditCards != nil {
-		for _, cc := range c.CreditCards.CreditCard {
-			paymentMethods = append(paymentMethods, cc)
-		}
-	}
-	if c.PayPalAccounts != nil {
-		for _, pp := range c.PayPalAccounts.PayPalAccount {
-			paymentMethods = append(paymentMethods, pp)
-		}
-	}
-	if c.ApplePayCards != nil {
-		for _, a := range c.ApplePayCards.ApplePayCard {
-			paymentMethods = append(paymentMethods, a)
-		}
-	}
+	paymentMethods = append(paymentMethods, c.CreditCards.PaymentMethods()...)
+	paymentMethods = append(paymentMethods, c.PayPalAccounts.PaymentMethods()...)
+	paymentMethods = append(paymentMethods, c.ApplePayCards.PaymentMethods()...)
 	return paymentMethods
 }
 

--- a/paypal_account.go
+++ b/paypal_account.go
@@ -22,6 +22,17 @@ type PayPalAccounts struct {
 	PayPalAccount []*PayPalAccount `xml:"paypal-account"`
 }
 
+func (pp *PayPalAccounts) PaymentMethods() []PaymentMethod {
+	if pp == nil {
+		return nil
+	}
+	var paymentMethods []PaymentMethod
+	for _, pp := range pp.PayPalAccount {
+		paymentMethods = append(paymentMethods, pp)
+	}
+	return paymentMethods
+}
+
 type PayPalAccountOptions struct {
 	MakeDefault bool `xml:"make-default,omitempty"`
 }


### PR DESCRIPTION
What
===
Reduce the many for loops in `Customer` `PaymentMethods()` by
getting lists of `PaymentMethod`s from each payment method definition
and appending them together.

Why
===
To reduce the amount of repeated code in the `Customer`
`PaymentMethods()` method.

Partially addresses @lionelbarrow's comment in #164.

Why not
===
This doesn't really simplify the code, since the code also needs to
include additional logic for appending. Having each payment method
definition own the function that returns a list of `PaymentMethod`s
doesn't gain us anything as we have no code within the package that
would use them. It also moves the code further away from where we
primarily need it.