### PR TITLE
Update the API sandbox and production URLs

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -16,8 +16,8 @@ func (e Environment) BaseURL() string {
 
 var (
 	Development = NewEnvironment("http://localhost:3000")
-	Sandbox     = NewEnvironment("https://sandbox.braintreegateway.com")
-	Production  = NewEnvironment("https://www.braintreegateway.com")
+	Sandbox     = NewEnvironment("https://api.sandbox.braintreegateway.com:443")
+	Production  = NewEnvironment("https://api.braintreegateway.com:443")
 )
 
 func EnvironmentFromName(name string) (Environment, error) {

--- a/environment_test.go
+++ b/environment_test.go
@@ -8,8 +8,8 @@ func TestEnvironmentBaseURL(t *testing.T) {
 		WantedBaseURL string
 	}{
 		{Development, "http://localhost:3000"},
-		{Sandbox, "https://sandbox.braintreegateway.com"},
-		{Production, "https://www.braintreegateway.com"},
+		{Sandbox, "https://api.sandbox.braintreegateway.com:443"},
+		{Production, "https://api.braintreegateway.com:443"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
What
===
Change the API sandbox and production URLs to include the `api.` prefix
subdomain and explicit port numbers.

Why
===
Looking at the official Braintree SDKs they seem to point to the same
domains we're using here but with an `api.` prefix and explicit ports.