### PR TITLE
Improve static analysis on ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,30 @@
 language: go
-matrix:
-  include:
-  - go: 1.6
-  - go: 1.7
-  - go: 1.8
-    env: ERRCHECK=true
-  - go: tip
-
 go_import_path: github.com/lionelbarrow/braintree-go
 
-install:
-  - if [ -n "$ERRCHECK" ] ; then go get -u github.com/kisielk/errcheck ; fi
+jobs:
+  include:
+    - stage: analysis
+      go: 1.8
+      script:
+        - go vet ./...
+        - go get -u github.com/kisielk/errcheck && CGO_ENABLED=0 errcheck ./...
+        - diff -u <(echo -n) <(gofmt -d .)
 
-script:
-  - source .default.env
-  - go vet ./...
-  - if [ -n "$ERRCHECK" ] ; then CGO_ENABLED=0 errcheck ./... ; else echo "Skipping errcheck" ; fi
-  - go test -parallel 15 -v ./...
+    - stage: test
+      go: 1.8
+      script:
+        - source .default.env
+        - go test -parallel 15 -v ./...
+
+    - stage: test
+      go: 1.7
+      script:
+        - source .default.env
+        - go test -parallel 15 -v ./...
+
+    - stage: test
+      go: 1.6
+      script:
+        - source .default.env
+        - go test -parallel 15 -v ./...
+


### PR DESCRIPTION
## What
* Add check that code is formatted using gofmt on CI runs.
* Move all analysis checks into a travis build stage that runs before tests.
* Remove the `tip` go build.
* Reorder builds so that newer versions are tested first.

### Screenshot (all passes)
![screen shot 2017-06-21 at 11 16 02 pm](https://user-images.githubusercontent.com/351529/27419807-a39d1132-56d7-11e7-843c-4df997927c51.png)

### Screenshot (analysis fails)
![screen shot 2017-06-21 at 11 15 38 pm](https://user-images.githubusercontent.com/351529/27419806-a2014f64-56d7-11e7-896c-5c35cf546d58.png)

## Why
To ensure code merged is formatted with gofmt and that's communicated clearly in the travis build page, and that the build pages is optimized to tell us what we care about most.