### PR TITLE
Consistency between local make and travisci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,24 @@
 language: go
 go_import_path: github.com/lionelbarrow/braintree-go
 
+install:
+  - source .default.env
+
 jobs:
   include:
     - stage: analysis
       go: 1.8
-      script:
-        - go vet ./...
-        - go get -u github.com/kisielk/errcheck && CGO_ENABLED=0 errcheck ./...
-        - diff -u <(echo -n) <(gofmt -d .)
+      script: make analysis
 
     - stage: test
       go: 1.8
-      script:
-        - source .default.env
-        - go test -parallel 15 -v ./...
+      script: make test
 
     - stage: test
       go: 1.7
-      script:
-        - source .default.env
-        - go test -parallel 15 -v ./...
+      script: make test
 
     - stage: test
       go: 1.6
-      script:
-        - source .default.env
-        - go test -parallel 15 -v ./...
+      script: make test
 

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,9 @@
+SHELL:=/bin/bash
+
 test:
 	go test -parallel 15 ./...
+
+analysis:
+	diff -u <(echo -n) <(gofmt -d .)
+	go vet ./...
+	go get github.com/kisielk/errcheck && CGO_ENABLED=0 errcheck ./...


### PR DESCRIPTION
What
===
Make the same commands available locally with make that travisci runs.

Why
===
To make it easy for someone developing to run the same tests and
expectations locally.