### PR TITLE
[RFC] Replace `*NullBool` and `*NullInt64` with `NullBool` and `NullInt64`

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -30,11 +30,11 @@ type Subscription struct {
 	FailureCount            string               `xml:"failure-count,omitempty"`
 	FirstBillingDate        string               `xml:"first-billing-date,omitempty"`
 	MerchantAccountId       string               `xml:"merchant-account-id,omitempty"`
-	NeverExpires            *nullable.NullBool   `xml:"never-expires,omitempty"`
+	NeverExpires            nullable.NullBool    `xml:"never-expires,omitempty"`
 	NextBillAmount          *Decimal             `xml:"next-bill-amount,omitempty"`
 	NextBillingPeriodAmount *Decimal             `xml:"next-billing-period-amount,omitempty"`
 	NextBillingDate         string               `xml:"next-billing-date,omitempty"`
-	NumberOfBillingCycles   *nullable.NullInt64  `xml:"number-of-billing-cycles,omitempty"`
+	NumberOfBillingCycles   nullable.NullInt64   `xml:"number-of-billing-cycles,omitempty"`
 	PaidThroughDate         string               `xml:"paid-through-date,omitempty"`
 	PaymentMethodToken      string               `xml:"payment-method-token,omitempty"`
 	PlanId                  string               `xml:"plan-id,omitempty"`
@@ -42,7 +42,7 @@ type Subscription struct {
 	Status                  SubscriptionStatus   `xml:"status,omitempty"`
 	TrialDuration           string               `xml:"trial-duration,omitempty"`
 	TrialDurationUnit       string               `xml:"trial-duration-unit,omitempty"`
-	TrialPeriod             *nullable.NullBool   `xml:"trial-period,omitempty"`
+	TrialPeriod             nullable.NullBool    `xml:"trial-period,omitempty"`
 	Transactions            *Transactions        `xml:"transactions,omitempty"`
 	Options                 *SubscriptionOptions `xml:"options,omitempty"`
 	Descriptor              *Descriptor          `xml:"descriptor,omitempty"`

--- a/subscription_integration_test.go
+++ b/subscription_integration_test.go
@@ -129,16 +129,16 @@ func TestSubscriptionAllFieldsWithBillingDayOfMonth(t *testing.T) {
 	if sub1.BillingDayOfMonth != "15" {
 		t.Fatalf("got billing day of month %#v, want %#v", sub1.BillingDayOfMonth, "15")
 	}
-	if x := sub1.NeverExpires; x == nil || !x.Valid || x.Bool {
+	if x := sub1.NeverExpires; !x.Valid || x.Bool {
 		t.Fatalf("got never expires %#v, want false", x)
 	}
-	if x := sub1.NumberOfBillingCycles; x == nil || !x.Valid || x.Int64 != 2 {
+	if x := sub1.NumberOfBillingCycles; !x.Valid || x.Int64 != 2 {
 		t.Fatalf("got number billing cycles %#v, want 2", x)
 	}
 	if x := sub1.Price; x == nil || x.Scale != 2 || x.Unscaled != 100 {
 		t.Fatalf("got price %#v, want 1.00", x)
 	}
-	if x := sub1.TrialPeriod; x == nil || !x.Valid || x.Bool {
+	if x := sub1.TrialPeriod; !x.Valid || x.Bool {
 		t.Fatalf("got trial period %#v, want false", x)
 	}
 	if x := sub1.Status; x != SubscriptionStatusPending {
@@ -243,16 +243,16 @@ func TestSubscriptionAllFieldsWithBillingDayOfMonthNeverExpires(t *testing.T) {
 	if sub1.BillingDayOfMonth != "15" {
 		t.Fatalf("got billing day of month %#v, want %#v", sub1.BillingDayOfMonth, "15")
 	}
-	if x := sub1.NeverExpires; x == nil || !x.Valid || !x.Bool {
+	if x := sub1.NeverExpires; !x.Valid || !x.Bool {
 		t.Fatalf("got never expires %#v, want true", x)
 	}
-	if x := sub1.NumberOfBillingCycles; x == nil || x.Valid {
+	if x := sub1.NumberOfBillingCycles; x.Valid {
 		t.Fatalf("got number billing cycles %#v, didn't want", x)
 	}
 	if x := sub1.Price; x == nil || x.Scale != 2 || x.Unscaled != 100 {
 		t.Fatalf("got price %#v, want 1.00", x)
 	}
-	if x := sub1.TrialPeriod; x == nil || !x.Valid || x.Bool {
+	if x := sub1.TrialPeriod; !x.Valid || x.Bool {
 		t.Fatalf("got trial period %#v, want false", x)
 	}
 	if x := sub1.Status; x != SubscriptionStatusPending {
@@ -360,16 +360,16 @@ func TestSubscriptionAllFieldsWithFirstBillingDate(t *testing.T) {
 	if sub1.FirstBillingDate != firstBillingDate {
 		t.Fatalf("got first billing date %#v, want %#v", sub1.FirstBillingDate, firstBillingDate)
 	}
-	if x := sub1.NeverExpires; x == nil || !x.Valid || x.Bool {
+	if x := sub1.NeverExpires; !x.Valid || x.Bool {
 		t.Fatalf("got never expires %#v, want false", x)
 	}
-	if x := sub1.NumberOfBillingCycles; x == nil || !x.Valid || x.Int64 != 2 {
+	if x := sub1.NumberOfBillingCycles; !x.Valid || x.Int64 != 2 {
 		t.Fatalf("got number billing cycles %#v, want 2", x)
 	}
 	if x := sub1.Price; x == nil || x.Scale != 2 || x.Unscaled != 100 {
 		t.Fatalf("got price %#v, want 1.00", x)
 	}
-	if x := sub1.TrialPeriod; x == nil || !x.Valid || x.Bool {
+	if x := sub1.TrialPeriod; !x.Valid || x.Bool {
 		t.Fatalf("got trial period %#v, want false", x)
 	}
 	if x := sub1.Status; x != SubscriptionStatusPending {
@@ -477,16 +477,16 @@ func TestSubscriptionAllFieldsWithFirstBillingDateNeverExpires(t *testing.T) {
 	if sub1.FirstBillingDate != firstBillingDate {
 		t.Fatalf("got first billing date %#v, want %#v", sub1.FirstBillingDate, firstBillingDate)
 	}
-	if x := sub1.NeverExpires; x == nil || !x.Valid || !x.Bool {
+	if x := sub1.NeverExpires; !x.Valid || !x.Bool {
 		t.Fatalf("got never expires %#v, want true", x)
 	}
-	if x := sub1.NumberOfBillingCycles; x == nil || x.Valid {
+	if x := sub1.NumberOfBillingCycles; x.Valid {
 		t.Fatalf("got number billing cycles %#v, didn't want", x)
 	}
 	if x := sub1.Price; x == nil || x.Scale != 2 || x.Unscaled != 100 {
 		t.Fatalf("got price %#v, want 1.00", x)
 	}
-	if x := sub1.TrialPeriod; x == nil || !x.Valid || x.Bool {
+	if x := sub1.TrialPeriod; !x.Valid || x.Bool {
 		t.Fatalf("got trial period %#v, want false", x)
 	}
 	if x := sub1.Status; x != SubscriptionStatusPending {
@@ -597,16 +597,16 @@ func TestSubscriptionAllFieldsWithTrialPeriod(t *testing.T) {
 	if sub1.FirstBillingDate != firstBillingDate.Format("2006-01-02") {
 		t.Fatalf("got first billing date %#v, want %#v", sub1.FirstBillingDate, firstBillingDate)
 	}
-	if x := sub1.NeverExpires; x == nil || !x.Valid || x.Bool {
+	if x := sub1.NeverExpires; !x.Valid || x.Bool {
 		t.Fatalf("got never expires %#v, want false", x)
 	}
-	if x := sub1.NumberOfBillingCycles; x == nil || !x.Valid || x.Int64 != 2 {
+	if x := sub1.NumberOfBillingCycles; !x.Valid || x.Int64 != 2 {
 		t.Fatalf("got number billing cycles %#v, want 2", x)
 	}
 	if x := sub1.Price; x == nil || x.Scale != 2 || x.Unscaled != 100 {
 		t.Fatalf("got price %#v, want 1.00", x)
 	}
-	if x := sub1.TrialPeriod; x == nil || !x.Valid || !x.Bool {
+	if x := sub1.TrialPeriod; !x.Valid || !x.Bool {
 		t.Fatalf("got trial period %#v, want false", x)
 	}
 	if sub1.TrialDuration != "7" {
@@ -720,16 +720,16 @@ func TestSubscriptionAllFieldsWithTrialPeriodNeverExpires(t *testing.T) {
 	if sub1.FirstBillingDate != firstBillingDate.Format("2006-01-02") {
 		t.Fatalf("got first billing date %#v, want %#v", sub1.FirstBillingDate, firstBillingDate)
 	}
-	if x := sub1.NeverExpires; x == nil || !x.Valid || !x.Bool {
+	if x := sub1.NeverExpires; !x.Valid || !x.Bool {
 		t.Fatalf("got never expires %#v, want true", x)
 	}
-	if x := sub1.NumberOfBillingCycles; x == nil || x.Valid {
+	if x := sub1.NumberOfBillingCycles; x.Valid {
 		t.Fatalf("got number billing cycles %#v, didn't want", x)
 	}
 	if x := sub1.Price; x == nil || x.Scale != 2 || x.Unscaled != 100 {
 		t.Fatalf("got price %#v, want 1.00", x)
 	}
-	if x := sub1.TrialPeriod; x == nil || !x.Valid || !x.Bool {
+	if x := sub1.TrialPeriod; !x.Valid || !x.Bool {
 		t.Fatalf("got trial period %#v, want false", x)
 	}
 	if sub1.TrialDuration != "7" {


### PR DESCRIPTION
What
===
Replace `*NullBool` and `*NullInt64` with `NullBool` and `NullInt64`.

Why
===
`*NullBool` and `*NullInt64` are cumbersome to use. To use the `Subscription` `NumberOfBillingCycles` bool variation as an example, the user of the struct must make two comparisons to safely inspect the value.

```go
type Subscription struct {
  ...
  NumberOfBillingCycles *NullInt64
  ...
}

subscription, _ := subscriptionGateway.Create(...)

if nobc := subscriptions.NumberOfBillingCycles; nobc != nil && nobc.Valid {
  fmt.Println("Subscription has a number of billing cycles of", nobc.Int64)
} else {
  fmt.Println("Subscription does not have number of billing cycles")
}
```

This change reduces the code above to:

```go
type Subscription struct {
  ...
  NumberOfBillingCycles NullInt64
  ...
}

subscription, _ := subscriptionGateway.Create(...)

if nobc := subscriptions.NumberOfBillingCycles; nobc.Valid {
  fmt.Println("Subscription has a number of billing cycles of", nobc.Int64)
} else {
  fmt.Println("Subscription does not have number of billing cycles")
}
```

This is better because:
 * The user needs only perform one check to determine if a value has been supplied.
 * Nullable types can be passed directly into `sql` queries to set `NULL` in nullable database columns.
 * The user does not need to deal with pointers at all.

However, there are downsides:
 * Some struct fields are considered empty if they are nil (e.g. `Address`), some use nullable structs. The inconsistency may trap users at times.
 * The user must know about the custom type, and may forget to check the `Valid` bool. If they do this their program may execute without error, but the consequences of misinterpreting the field could be significant.

Alternatives
===
See #176.

@ccahoon @knifeedge @jszwedko @lionelbarrow 