### PR TITLE
Remove nullables from search result structs

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -2,7 +2,6 @@ package braintree
 
 import (
 	"github.com/lionelbarrow/braintree-go/customfields"
-	"github.com/lionelbarrow/braintree-go/nullable"
 )
 
 type Customer struct {
@@ -57,9 +56,9 @@ func (c *Customer) DefaultPaymentMethod() PaymentMethod {
 }
 
 type CustomerSearchResult struct {
-	XMLName           string              `xml:"customers"`
-	CurrentPageNumber *nullable.NullInt64 `xml:"current-page-number"`
-	PageSize          *nullable.NullInt64 `xml:"page-size"`
-	TotalItems        *nullable.NullInt64 `xml:"total-items"`
-	Customers         []*Customer         `xml:"customer"`
+	XMLName           string      `xml:"customers"`
+	CurrentPageNumber int         `xml:"current-page-number"`
+	PageSize          int         `xml:"page-size"`
+	TotalItems        int         `xml:"total-items"`
+	Customers         []*Customer `xml:"customer"`
 }

--- a/disbursement_integration_test.go
+++ b/disbursement_integration_test.go
@@ -18,7 +18,7 @@ func TestDisbursementTransactions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !result.TotalItems.Valid || result.TotalItems.Int64 != 1 {
+	if result.TotalItems != 1 {
 		t.Fatal(result)
 	}
 

--- a/transaction.go
+++ b/transaction.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/lionelbarrow/braintree-go/customfields"
-	"github.com/lionelbarrow/braintree-go/nullable"
 )
 
 type TransactionStatus string
@@ -152,11 +151,11 @@ type TransactionOptions struct {
 }
 
 type TransactionSearchResult struct {
-	XMLName           string              `xml:"credit-card-transactions"`
-	CurrentPageNumber *nullable.NullInt64 `xml:"current-page-number"`
-	PageSize          *nullable.NullInt64 `xml:"page-size"`
-	TotalItems        *nullable.NullInt64 `xml:"total-items"`
-	Transactions      []*Transaction      `xml:"transaction"`
+	XMLName           string         `xml:"credit-card-transactions"`
+	CurrentPageNumber int            `xml:"current-page-number"`
+	PageSize          int            `xml:"page-size"`
+	TotalItems        int            `xml:"total-items"`
+	Transactions      []*Transaction `xml:"transaction"`
 }
 
 type RiskData struct {

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -107,7 +107,7 @@ func TestTransactionSearch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !result.TotalItems.Valid || result.TotalItems.Int64 != 1 {
+	if result.TotalItems != 1 {
 		t.Fatal(result.Transactions)
 	}
 
@@ -159,7 +159,7 @@ func TestTransactionSearchTime(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !result.TotalItems.Valid || result.TotalItems.Int64 != 1 {
+		if result.TotalItems != 1 {
 			t.Fatal(result.Transactions)
 		}
 
@@ -182,7 +182,7 @@ func TestTransactionSearchTime(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !result.TotalItems.Valid || result.TotalItems.Int64 != 0 {
+		if result.TotalItems != 0 {
 			t.Fatal(result.Transactions)
 		}
 	}


### PR DESCRIPTION
What
===
Remove nullables from search result structs.

Why
===
They are unnecessary. From what I can tell the structs will always have
values for the number of items in the struct. If in some case we
received an error response and the struct was built and returned it
would show a total count of zero, which is not so bad and better than
dealing with null objects.