### PR TITLE
Add transaction options for paypal request

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -168,11 +168,11 @@ func (s supplementaryDataMap) MarshalXML(e *xml.Encoder, start xml.StartElement)
 	tokens := []xml.Token{start}
 
 	for key, value := range s {
-		t := xml.StartElement{Name: xml.Name{"", key}}
-		tokens = append(tokens, t, xml.CharData(value), xml.EndElement{t.Name})
+		t := xml.StartElement{Name: xml.Name{Space: "", Local: key}}
+		tokens = append(tokens, t, xml.CharData(value), xml.EndElement{Name: t.Name})
 	}
 
-	tokens = append(tokens, xml.EndElement{start.Name})
+	tokens = append(tokens, xml.EndElement{Name: start.Name})
 
 	for _, t := range tokens {
 		err := e.EncodeToken(t)

--- a/transaction.go
+++ b/transaction.go
@@ -146,10 +146,18 @@ type Transactions struct {
 }
 
 type TransactionOptions struct {
-	SubmitForSettlement              bool `xml:"submit-for-settlement,omitempty"`
-	StoreInVault                     bool `xml:"store-in-vault,omitempty"`
-	AddBillingAddressToPaymentMethod bool `xml:"add-billing-address-to-payment-method,omitempty"`
-	StoreShippingAddressInVault      bool `xml:"store-shipping-address-in-vault,omitempty"`
+	SubmitForSettlement              bool                             `xml:"submit-for-settlement,omitempty"`
+	StoreInVault                     bool                             `xml:"store-in-vault,omitempty"`
+	AddBillingAddressToPaymentMethod bool                             `xml:"add-billing-address-to-payment-method,omitempty"`
+	StoreShippingAddressInVault      bool                             `xml:"store-shipping-address-in-vault,omitempty"`
+	TransactionOptionsPaypalRequest  *TransactionOptionsPaypalRequest `xml:"paypal,omitempty"`
+}
+
+type TransactionOptionsPaypalRequest struct {
+	CustomField       string            `xml:"custom-field,omitempty"`
+	PayeeEmail        string            `xml:"payee-email,omitempty"`
+	Description       string            `xml:"description,omitempty"`
+	SupplementaryData map[string]string `xml:"supplementary-data,omitempty"`
 }
 
 type TransactionSearchResult struct {

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -496,7 +496,10 @@ func TestTransactionPaypalFields(t *testing.T) {
 	const (
 		PayeeEmail  = "payee@payal.com"
 		Description = "One tasty sandwich"
+		CustomField = "foo"
 	)
+	subData := make(map[string]string)
+	subData["faz"] = "bar"
 
 	customer, err := testGateway.Customer().Create(&Customer{})
 	if err != nil {
@@ -525,8 +528,10 @@ func TestTransactionPaypalFields(t *testing.T) {
 		Options: &TransactionOptions{
 			SubmitForSettlement: true,
 			TransactionOptionsPaypalRequest: &TransactionOptionsPaypalRequest{
-				PayeeEmail:  PayeeEmail,
-				Description: Description,
+				PayeeEmail:        PayeeEmail,
+				Description:       Description,
+				CustomField:       CustomField,
+				SupplementaryData: subData,
 			},
 		},
 	}
@@ -548,6 +553,9 @@ func TestTransactionPaypalFields(t *testing.T) {
 	}
 	if tx2.PayPalDetails.Description != Description {
 		t.Fatalf("expected tx2.PaypalDetails.Description to be %s, but got %s", Description, tx2.PayPalDetails.Description)
+	}
+	if tx2.PayPalDetails.CustomField != CustomField {
+		t.Fatalf("expected tx2.PayPalDetails.CustomField to be %s, but got %s", CustomField, tx2.PayPalDetails.CustomField)
 	}
 }
 

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -489,6 +489,68 @@ func TestTransactionDescriptorFields(t *testing.T) {
 	}
 }
 
+// This test will fail unless you set up your Braintree sandbox account correctly. See TESTING.md for details.
+func TestTransactionPaypalFields(t *testing.T) {
+	t.Parallel()
+
+	const (
+		PayeeEmail  = "payee@payal.com"
+		Description = "One tasty sandwich"
+	)
+
+	customer, err := testGateway.Customer().Create(&Customer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nonce := FakeNoncePayPalFuturePayment
+
+	paymentMethod, err := testGateway.PaymentMethod().Create(&PaymentMethodRequest{
+		CustomerId:         customer.Id,
+		PaymentMethodNonce: nonce,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	paypalAccount, ok := paymentMethod.(*PayPalAccount)
+	if !ok {
+		t.Fatal("Could not assert paypal account")
+	}
+
+	tx := &TransactionRequest{
+		Type:               "sale",
+		Amount:             randomAmount(),
+		PaymentMethodToken: paypalAccount.GetToken(),
+		OrderId:            "123456ABC",
+		Options: &TransactionOptions{
+			SubmitForSettlement: true,
+			TransactionOptionsPaypalRequest: &TransactionOptionsPaypalRequest{
+				PayeeEmail:  PayeeEmail,
+				Description: Description,
+			},
+		},
+	}
+	tx2, err := testGateway.Transaction().Create(tx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tx2.Type != tx.Type {
+		t.Fatalf("expected Type to be equal, but %s was not %s", tx2.Type, tx.Type)
+	}
+	if tx2.Amount.Cmp(tx.Amount) != 0 {
+		t.Fatalf("expected Amount to be equal, but %s was not %s", tx2.Amount, tx.Amount)
+	}
+	if tx2.Status != TransactionStatusSettling {
+		t.Fatalf("expected tx2.Status to be %s, but got %s", TransactionStatusSettling, tx2.Status)
+	}
+	if tx2.PayPalDetails.PayeeEmail != PayeeEmail {
+		t.Fatalf("expected tx2.PaypalDetails.PayeeEmail to be %s, but got %s", PayeeEmail, tx2.PayPalDetails.PayeeEmail)
+	}
+	if tx2.PayPalDetails.Description != Description {
+		t.Fatalf("expected tx2.PaypalDetails.Description to be %s, but got %s", Description, tx2.PayPalDetails.Description)
+	}
+}
+
 func TestTransactionRiskDataFields(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This is basically the port from the official  [Java-Library](https://github.com/braintree/braintree_java/blob/7a36af1760392222ab371d610effa0e690dc878d/src/main/java/com/braintreegateway/TransactionOptionsPayPalRequest.java) to support sending PayPal-specific options while creating a transaction.

Let me know if there is missing something 😄  Thanks for your awesome work!