### PR TITLE
Change TransactionStatus type to string type to eliminate unnecessary type assertions

### DIFF
--- a/search_test.go
+++ b/search_test.go
@@ -61,9 +61,9 @@ func TestSearchXMLEncode(t *testing.T) {
 
 	f14 := s.AddMultiField("status")
 	f14.Items = []string{
-		string(TransactionStatusAuthorized),
-		string(TransactionStatusSubmittedForSettlement),
-		string(TransactionStatusSettled),
+		TransactionStatusAuthorized,
+		TransactionStatusSubmittedForSettlement,
+		TransactionStatusSettled,
 	}
 
 	b, err := xml.MarshalIndent(s, "", "  ")

--- a/testing_gateway.go
+++ b/testing_gateway.go
@@ -25,9 +25,9 @@ func (g *TestingGateway) SettlementPending(transactionID string) (*Transaction, 
 	return g.setStatus(transactionID, TransactionStatusSettlementPending)
 }
 
-func (g *TestingGateway) setStatus(transactionID string, status TransactionStatus) (*Transaction, error) {
+func (g *TestingGateway) setStatus(transactionID string, status string) (*Transaction, error) {
 	if g.Environment() != Production {
-		resp, err := g.execute("PUT", "transactions/"+transactionID+"/"+string(status), nil)
+		resp, err := g.execute("PUT", "transactions/"+transactionID+"/"+status, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/transaction.go
+++ b/transaction.go
@@ -6,29 +6,27 @@ import (
 	"github.com/lionelbarrow/braintree-go/customfields"
 )
 
-type TransactionStatus string
-
 const (
-	TransactionStatusAuthorizationExpired   TransactionStatus = "authorization_expired"
-	TransactionStatusAuthorizing            TransactionStatus = "authorizing"
-	TransactionStatusAuthorized             TransactionStatus = "authorized"
-	TransactionStatusGatewayRejected        TransactionStatus = "gateway_rejected"
-	TransactionStatusFailed                 TransactionStatus = "failed"
-	TransactionStatusProcessorDeclined      TransactionStatus = "processor_declined"
-	TransactionStatusSettled                TransactionStatus = "settled"
-	TransactionStatusSettlementConfirmed    TransactionStatus = "settlement_confirmed"
-	TransactionStatusSettlementDeclined     TransactionStatus = "settlement_declined"
-	TransactionStatusSettlementPending      TransactionStatus = "settlement_pending"
-	TransactionStatusSettling               TransactionStatus = "settling"
-	TransactionStatusSubmittedForSettlement TransactionStatus = "submitted_for_settlement"
-	TransactionStatusVoided                 TransactionStatus = "voided"
-	TransactionStatusUnrecognized           TransactionStatus = "unrecognized"
+	TransactionStatusAuthorizationExpired   = "authorization_expired"
+	TransactionStatusAuthorizing            = "authorizing"
+	TransactionStatusAuthorized             = "authorized"
+	TransactionStatusGatewayRejected        = "gateway_rejected"
+	TransactionStatusFailed                 = "failed"
+	TransactionStatusProcessorDeclined      = "processor_declined"
+	TransactionStatusSettled                = "settled"
+	TransactionStatusSettlementConfirmed    = "settlement_confirmed"
+	TransactionStatusSettlementDeclined     = "settlement_declined"
+	TransactionStatusSettlementPending      = "settlement_pending"
+	TransactionStatusSettling               = "settling"
+	TransactionStatusSubmittedForSettlement = "submitted_for_settlement"
+	TransactionStatusVoided                 = "voided"
+	TransactionStatusUnrecognized           = "unrecognized"
 )
 
 type Transaction struct {
 	XMLName                      string                    `xml:"transaction"`
 	Id                           string                    `xml:"id,omitempty"`
-	Status                       TransactionStatus         `xml:"status,omitempty"`
+	Status                       string                    `xml:"status,omitempty"`
 	Type                         string                    `xml:"type,omitempty"`
 	CurrencyISOCode              string                    `xml:"currency-iso-code,omitempty"`
 	Amount                       *Decimal                  `xml:"amount"`


### PR DESCRIPTION
When the constants were added in [#154](https://github.com/lionelbarrow/braintree-go/pull/154) they could have been of type string versus TransactionStatus. The type doesn't provide any extra functionality, and now requires an unneeded type assertion.