### PR TITLE
Fix flaky subscription billing day of month tests

### DIFF
--- a/subscription_integration_test.go
+++ b/subscription_integration_test.go
@@ -137,8 +137,8 @@ func TestSubscriptionAllFieldsWithBillingDayOfMonth(t *testing.T) {
 	if x := sub1.TrialPeriod; x {
 		t.Fatalf("got trial period %#v, want false", x)
 	}
-	if x := sub1.Status; x != SubscriptionStatusPending {
-		t.Fatalf("got status %#v, want Pending", x)
+	if x := sub1.Status; x != SubscriptionStatusPending && x != SubscriptionStatusActive {
+		t.Fatalf("got status %#v, want Pending or Active (it will be active if todays date matches the billing day of month)", x)
 	}
 	if x := sub1.Descriptor.Name; x != "Company Name*Product 1" {
 		t.Fatalf("got descriptor name %#v, want Company Name*Product 1", x)
@@ -249,8 +249,8 @@ func TestSubscriptionAllFieldsWithBillingDayOfMonthNeverExpires(t *testing.T) {
 	if x := sub1.TrialPeriod; x {
 		t.Fatalf("got trial period %#v, want false", x)
 	}
-	if x := sub1.Status; x != SubscriptionStatusPending {
-		t.Fatalf("got status %#v, want Pending", x)
+	if x := sub1.Status; x != SubscriptionStatusPending && x != SubscriptionStatusActive {
+		t.Fatalf("got status %#v, want Pending or Active (it will be active if todays date matches the billing day of month)", x)
 	}
 	if x := sub1.Descriptor.Name; x != "Company Name*Product 1" {
 		t.Fatalf("got descriptor name %#v, want Company Name*Product 1", x)


### PR DESCRIPTION
What
===
Allow subscription tests that set a billing day of month to pass if
their status is active and not pending after creation.

Why
===
The tests use a fixed billing day of month of the 15th of the month. If
the subscriptions are created on the 15th, the subscription will go
active immediately rather than be returned in a pending state. This was
causing the tests to fail on the 15th of each month.