### PR TITLE
Add channel

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -66,6 +66,7 @@ type Transaction struct {
 	AdditionalProcessorResponse  string                    `xml:"additional-processor-response,omitempty"`
 	RiskData                     *RiskData                 `xml:"risk-data,omitempty"`
 	Descriptor                   *Descriptor               `xml:"descriptor,omitempty"`
+	Channel                      string                    `xml:"channel,omitempty"`
 	CustomFields                 customfields.CustomFields `xml:"custom-fields,omitempty"`
 	AVSErrorResponseCode         AVSResponseCode           `xml:"avs-error-response-code,omitempty"`
 	AVSPostalCodeResponseCode    AVSResponseCode           `xml:"avs-postal-code-response-code,omitempty"`
@@ -95,6 +96,7 @@ type TransactionRequest struct {
 	ServiceFeeAmount   *Decimal                  `xml:"service-fee-amount,attr,omitempty"`
 	RiskData           *RiskDataRequest          `xml:"risk-data,omitempty"`
 	Descriptor         *Descriptor               `xml:"descriptor,omitempty"`
+	Channel            string                    `xml:"channel,omitempty"`
 	CustomFields       customfields.CustomFields `xml:"custom-fields,omitempty"`
 }
 

--- a/transaction_clone.go
+++ b/transaction_clone.go
@@ -3,6 +3,7 @@ package braintree
 type TransactionCloneRequest struct {
 	XMLName string                   `xml:"transaction-clone"`
 	Amount  *Decimal                 `xml:"amount"`
+	Channel string                   `xml:"channel"`
 	Options *TransactionCloneOptions `xml:"options"`
 }
 

--- a/transaction_clone_integration_test.go
+++ b/transaction_clone_integration_test.go
@@ -20,7 +20,8 @@ func TestTransactionClone(t *testing.T) {
 
 	// Clone
 	tx2, err := testGateway.Transaction().Clone(tx.Id, &TransactionCloneRequest{
-		Amount: NewDecimal(1000, 2),
+		Amount:  NewDecimal(1000, 2),
+		Channel: "ChannelA",
 		Options: &TransactionCloneOptions{
 			SubmitForSettlement: false,
 		},
@@ -34,6 +35,9 @@ func TestTransactionClone(t *testing.T) {
 	}
 	if g, w := tx2.Amount, NewDecimal(1000, 2); g.Cmp(w) != 0 {
 		t.Errorf("Transaction amount got %v, want %v", g, w)
+	}
+	if g, w := tx2.Channel, "ChannelA"; g != w {
+		t.Errorf("Transaction channel got %v, want %v", g, w)
 	}
 	if g, w := tx2.CreditCard.ExpirationMonth, "05"; g != w {
 		t.Errorf("Transaction credit card expiration month got %v, want %v", g, w)
@@ -64,7 +68,8 @@ func TestTransactionCloneSubmittedForSettlement(t *testing.T) {
 
 	// Clone
 	tx2, err := testGateway.Transaction().Clone(tx.Id, &TransactionCloneRequest{
-		Amount: NewDecimal(1000, 2),
+		Amount:  NewDecimal(1000, 2),
+		Channel: "ChannelA",
 		Options: &TransactionCloneOptions{
 			SubmitForSettlement: true,
 		},
@@ -78,6 +83,9 @@ func TestTransactionCloneSubmittedForSettlement(t *testing.T) {
 	}
 	if g, w := tx2.Amount, NewDecimal(1000, 2); g.Cmp(w) != 0 {
 		t.Errorf("Transaction amount got %v, want %v", g, w)
+	}
+	if g, w := tx2.Channel, "ChannelA"; g != w {
+		t.Errorf("Transaction channel got %v, want %v", g, w)
 	}
 	if g, w := tx2.CreditCard.ExpirationMonth, "05"; g != w {
 		t.Errorf("Transaction credit card expiration month got %v, want %v", g, w)

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -617,6 +617,7 @@ func TestAllTransactionFields(t *testing.T) {
 		},
 		TaxAmount:  taxAmount,
 		DeviceData: `{"device_session_id": "dsi_1234", "fraud_merchant_id": "fmi_1234", "correlation_id": "ci_1234"}`,
+		Channel:    "ChannelA",
 		Options: &TransactionOptions{
 			SubmitForSettlement:              true,
 			StoreInVault:                     true,
@@ -701,6 +702,9 @@ func TestAllTransactionFields(t *testing.T) {
 	}
 	if tx2.RiskData.Decision != "Approve" {
 		t.Fatalf("expected tx2.RiskData.Decision to be Approve, but got %s", tx2.RiskData.Decision)
+	}
+	if tx2.Channel != "ChannelA" {
+		t.Fatalf("expected tx2.Channel to be ChannelA, but got %s", tx2.Channel)
 	}
 }
 


### PR DESCRIPTION
Add the channel field to transaction and to transaction clone requests. This was first partially included in #185 by @dsmcfarl, but moved to a separate PR to more broadly support channel.