### PR TITLE
Allow card verification to be turned off

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -23,6 +23,10 @@ When using Braintree Go in a production environment, we recommend that you conti
 
 #### Sandbox settings
 
+In your sandbox account go to `Settings > Processing` and enable the following
+
+  1. `Card Verification`
+
 In your sandbox account go to `Settings > Processing > CVV` and enable the following
 
   1. `CVV does not match (when provided) (N)` to `For Any Transaction`

--- a/credit_card.go
+++ b/credit_card.go
@@ -57,7 +57,7 @@ func (cards *CreditCards) PaymentMethods() []PaymentMethod {
 }
 
 type CreditCardOptions struct {
-	VerifyCard                    bool   `xml:"verify-card,omitempty"`
+	VerifyCard                    *bool  `xml:"verify-card,omitempty"`
 	VenmoSDKSession               string `xml:"venmo-sdk-session,omitempty"`
 	MakeDefault                   bool   `xml:"make-default,omitempty"`
 	FailOnDuplicatePaymentMethod  bool   `xml:"fail-on-duplicate-payment-method,omitempty"`

--- a/customer_integration_test.go
+++ b/customer_integration_test.go
@@ -25,7 +25,7 @@ func TestCustomer(t *testing.T) {
 			ExpirationDate: "05/14",
 			CVV:            "200",
 			Options: &CreditCardOptions{
-				VerifyCard: true,
+				VerifyCard: testhelpers.BoolPtr(true),
 			},
 		},
 	}

--- a/examples/subscription/server.go
+++ b/examples/subscription/server.go
@@ -70,7 +70,7 @@ func main() {
 			// The nonce from the clinet side
 			PaymentMethodNonce: paymentMethodNonce,
 			Options: &braintree.CreditCardOptions{
-				VerifyCard: true,
+				VerifyCard: func(b bool) *bool { return &b }(true),
 			},
 		})
 		if err != nil {

--- a/go_fixes_bug_5452_xml_omitempty.go
+++ b/go_fixes_bug_5452_xml_omitempty.go
@@ -1,0 +1,95 @@
+// +build !go1.8
+
+package braintree
+
+import "encoding/xml"
+
+// The functions in this file are required because of a bug in versions of go prior to go1.8.
+// The bug was reported at https://github.com/golang/go/issues/5452 and fixed in
+// https://github.com/golang/go/commit/daa121167b6ce630aba00195f1c3872cda39a50c.
+//
+// In versions prior to go1.8 the XML encoder did not include pointer fields that were non-nil
+// if the field pointed to a value that was the default value for the pointed to type.
+//
+// To serialize the bool false value when it is set on `VerifyCard`, we must manually control
+// if it is serialized or not.
+
+func (cco *CreditCardOptions) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if cco.VerifyCard == nil {
+		type excludeVerifyCard struct {
+			VerifyCard                    *bool  `xml:"-"`
+			VenmoSDKSession               string `xml:"venmo-sdk-session,omitempty"`
+			MakeDefault                   bool   `xml:"make-default,omitempty"`
+			FailOnDuplicatePaymentMethod  bool   `xml:"fail-on-duplicate-payment-method,omitempty"`
+			VerificationMerchantAccountId string `xml:"verification-merchant-account-id,omitempty"`
+			UpdateExistingToken           string `xml:"update-existing-token,omitempty"`
+		}
+		return e.EncodeElement(
+			excludeVerifyCard{
+				VerifyCard:                    cco.VerifyCard,
+				VenmoSDKSession:               cco.VenmoSDKSession,
+				MakeDefault:                   cco.MakeDefault,
+				FailOnDuplicatePaymentMethod:  cco.FailOnDuplicatePaymentMethod,
+				VerificationMerchantAccountId: cco.VerificationMerchantAccountId,
+				UpdateExistingToken:           cco.UpdateExistingToken,
+			},
+			start,
+		)
+	} else {
+		type includeVerifyCard struct {
+			VerifyCard                    *bool  `xml:"verify-card"`
+			VenmoSDKSession               string `xml:"venmo-sdk-session,omitempty"`
+			MakeDefault                   bool   `xml:"make-default,omitempty"`
+			FailOnDuplicatePaymentMethod  bool   `xml:"fail-on-duplicate-payment-method,omitempty"`
+			VerificationMerchantAccountId string `xml:"verification-merchant-account-id,omitempty"`
+			UpdateExistingToken           string `xml:"update-existing-token,omitempty"`
+		}
+		return e.EncodeElement(
+			includeVerifyCard{
+				VerifyCard:                    cco.VerifyCard,
+				VenmoSDKSession:               cco.VenmoSDKSession,
+				MakeDefault:                   cco.MakeDefault,
+				FailOnDuplicatePaymentMethod:  cco.FailOnDuplicatePaymentMethod,
+				VerificationMerchantAccountId: cco.VerificationMerchantAccountId,
+				UpdateExistingToken:           cco.UpdateExistingToken,
+			},
+			start,
+		)
+	}
+}
+
+func (pmo *PaymentMethodRequestOptions) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if pmo.VerifyCard == nil {
+		type excludeVerifyCard struct {
+			MakeDefault                   bool   `xml:"make-default,omitempty"`
+			FailOnDuplicatePaymentMethod  bool   `xml:"fail-on-duplicate-payment-method,omitempty"`
+			VerifyCard                    *bool  `xml:"-"`
+			VerificationMerchantAccountId string `xml:"verification-merchant-account-id,omitempty"`
+		}
+		return e.EncodeElement(
+			excludeVerifyCard{
+				MakeDefault:                   pmo.MakeDefault,
+				FailOnDuplicatePaymentMethod:  pmo.FailOnDuplicatePaymentMethod,
+				VerifyCard:                    pmo.VerifyCard,
+				VerificationMerchantAccountId: pmo.VerificationMerchantAccountId,
+			},
+			start,
+		)
+	} else {
+		type includeVerifyCard struct {
+			MakeDefault                   bool   `xml:"make-default,omitempty"`
+			FailOnDuplicatePaymentMethod  bool   `xml:"fail-on-duplicate-payment-method,omitempty"`
+			VerifyCard                    *bool  `xml:"verify-card"`
+			VerificationMerchantAccountId string `xml:"verification-merchant-account-id,omitempty"`
+		}
+		return e.EncodeElement(
+			includeVerifyCard{
+				MakeDefault:                   pmo.MakeDefault,
+				FailOnDuplicatePaymentMethod:  pmo.FailOnDuplicatePaymentMethod,
+				VerifyCard:                    pmo.VerifyCard,
+				VerificationMerchantAccountId: pmo.VerificationMerchantAccountId,
+			},
+			start,
+		)
+	}
+}

--- a/payment_method_gateway.go
+++ b/payment_method_gateway.go
@@ -17,7 +17,7 @@ type PaymentMethodRequest struct {
 type PaymentMethodRequestOptions struct {
 	MakeDefault                   bool   `xml:"make-default,omitempty"`
 	FailOnDuplicatePaymentMethod  bool   `xml:"fail-on-duplicate-payment-method,omitempty"`
-	VerifyCard                    bool   `xml:"verify-card,omitempty"`
+	VerifyCard                    *bool  `xml:"verify-card,omitempty"`
 	VerificationMerchantAccountId string `xml:"verification-merchant-account-id,omitempty"`
 }
 


### PR DESCRIPTION
What
===
Change the type of the `VerifyCard` option from `bool` to `*bool`.

Why
===
For merchants who have payment method verification required in their
control panel, they are unable to set the value of `VerifyCard` to
`false` and disable verification for specific payment methods like they
can with other Braintree SDKs.

This happens because the `VerifyCard` field of `CreditCardOptions` and
`PaymentMethodRequestOptions` is tagged as `omitempty`, because we only
want to send the value to the gateway if the merchant has explicitly set
a value. Combined with the type of `bool`, this means if a merchant sets
the value as `false`, we don't send it to the gateway.

Making this field a `*bool` and `omitempty` will mean the field is not
sent if it is `nil` (not set), but will be sent if it is given the value
of `false` or `true.

This issue was raised in #179.

Note
===
There is additional marshaling code added to make the VerifyCard field
marshal correctly on versions of go prior to go1.8.