### PR TITLE
Add log flag to go test runs.

### DIFF
--- a/test_values.go
+++ b/test_values.go
@@ -1,7 +1,9 @@
 package braintree
 
 import (
+	"flag"
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -69,4 +71,13 @@ func testSubMerchantAccount() string {
 	}
 
 	return merchantAccount.Id
+}
+
+func init() {
+	logEnabled := flag.Bool("log", false, "enables logging")
+	flag.Parse()
+
+	if *logEnabled {
+		testGateway.Logger = log.New(os.Stderr, "", 0)
+	}
 }


### PR DESCRIPTION
What
===
Add `log` flag to go test runs. If `-log` is added to any `go test` the
tests will log the xml sent and received with the Braintree API.

Why
===
I often find myself setting a logger when inspecting messages when
adding new tests or investigating an issue. It seems like it'd be handy
to be able to turn it on/off as needed.