### PR TITLE
Remove Go1.6 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,6 @@ jobs:
       go: 1.7
       script: make test
 
-    - stage: test
-      go: 1.6
-      script: make test
-
     - stage: analysis-is-backward-compatible-with-master
       go: 1.9
       script: make analysis-is-backward-compatible-with-master

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ The usual. `go get github.com/lionelbarrow/braintree-go`
 
 ### Supported Go Versions
 
-* 1.6
 * 1.7
 * 1.8
 * 1.9


### PR DESCRIPTION
What
===
Remove Go1.6 support, with support now being Go1.7+.

Why
===
Go1.6 is the last version of Go that does not have the `context` stdlib
package. Removing support for Go1.6 makes it significantly easier for us
to make progress on adding support for `context` (#156).

The main motivation for maintaining support for Go1.6 up until now was
that Google AppEngine supported only Go1.6. Google recently announced
general availability of Go1.8 in AppEngine and it is now the default
version within that product. While Go1.6 is still supported for already
deployed applications it's reasonable to expect importers of
braintree-go to upgrade their version of Go for the next version.

We could restrict support further to Go1.8 but there are no significant
wins for dropping Go1.7 support at this time. There is one fix in the
`go_fixes_bug_5452_xml_omitempty.go` file that works around a bug in
Go1.7, but this is not a burden at the moment.