### PR TITLE
Add NumberOfBillingCycles to Modifications

### DIFF
--- a/modification.go
+++ b/modification.go
@@ -8,12 +8,13 @@ const (
 )
 
 type Modification struct {
-	Id           string     `xml:"id,omitempty"`
-	Amount       *Decimal   `xml:"amount,omitempty"`
-	Description  string     `xml:"description,omitempty"`
-	Kind         string     `xml:"kind,omitempty"`
-	Name         string     `xml:"name,omitempty"`
-	NeverExpires bool       `xml:"never-expires,omitempty"`
-	Quantity     int        `xml:"quantity,omitempty"`
-	UpdatedAt    *time.Time `xml:"updated_at,omitempty"`
+	Id                    string     `xml:"id,omitempty"`
+	Amount                *Decimal   `xml:"amount,omitempty"`
+	Description           string     `xml:"description,omitempty"`
+	Kind                  string     `xml:"kind,omitempty"`
+	Name                  string     `xml:"name,omitempty"`
+	NeverExpires          bool       `xml:"never-expires,omitempty"`
+	Quantity              int        `xml:"quantity,omitempty"`
+	NumberOfBillingCycles int        `xml:"number-of-billing-cycles"`
+	UpdatedAt             *time.Time `xml:"updated_at,omitempty"`
 }

--- a/plan_integration_test.go
+++ b/plan_integration_test.go
@@ -91,6 +91,8 @@ func TestPlan(t *testing.T) {
 		t.Fatalf("expected NeverExpires to be %v, was %v", true, addOn.NeverExpires)
 	} else if addOn.Description != "A test add-on" {
 		t.Fatalf("expected Description to be %s, was %s", "A test add-on", addOn.Description)
+	} else if addOn.NumberOfBillingCycles != 0 {
+		t.Fatalf("expected NumberOfBillingCycles to be %d, was %d", 0, addOn.NumberOfBillingCycles)
 	}
 
 	// Discounts
@@ -111,6 +113,8 @@ func TestPlan(t *testing.T) {
 		t.Fatalf("expected NeverExpires to be %v, was %v", true, discount.NeverExpires)
 	} else if discount.Description != "A test discount" {
 		t.Fatalf("expected Description to be %s, was %s", "A test discount", discount.Description)
+	} else if discount.NumberOfBillingCycles != 0 {
+		t.Fatalf("expected NumberOfBillingCycles to be %d, was %d", 0, discount.NumberOfBillingCycles)
 	}
 
 	// Find

--- a/subscription_integration_test.go
+++ b/subscription_integration_test.go
@@ -853,9 +853,9 @@ func TestSubscriptionModifications(t *testing.T) {
 				{
 					InheritedFromID: "test_discount",
 					ModificationRequest: ModificationRequest{
-						Amount:       NewDecimal(100, 2),
-						Quantity:     1,
-						NeverExpires: true,
+						Amount:                NewDecimal(100, 2),
+						Quantity:              1,
+						NumberOfBillingCycles: 2,
 					},
 				},
 			},
@@ -884,6 +884,9 @@ func TestSubscriptionModifications(t *testing.T) {
 	}
 	if x := sub2.Discounts.Discounts[0].Amount; x.String() != NewDecimal(100, 2).String() {
 		t.Fatalf("got %v discount, want 1.00 discount", x)
+	}
+	if x := sub2.Discounts.Discounts[0].NumberOfBillingCycles; x != 2 {
+		t.Fatalf("got %v number of billing cycles on discount, want 2 billing cycles", x)
 	}
 
 	// Update AddOn


### PR DESCRIPTION
What
===
Add NumberOfBillingCycles to Modification and subsequently AddOn and
Discount structs that are used with Plans and Subscriptions.

Why
===
Requested in #199, the field is present on modifications but was not
being deserialized.

@buola