### PR TITLE
Add build tags for unit and integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 SHELL:=/bin/bash
 
 test:
-	go test -parallel 15 ./...
+	go test -parallel 15 -tags='unit integration' ./...
+
+unit:
+	go test -tags=unit ./...
+
+integration:
+	go test -parallel 15 -tags=integration ./...
 
 analysis:
 	diff -u <(echo -n) <(gofmt -d .)

--- a/add_on_integration_test.go
+++ b/add_on_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/address_integration_test.go
+++ b/address_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/android_pay_card_test.go
+++ b/android_pay_card_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package braintree
 
 import (

--- a/android_pay_details_test.go
+++ b/android_pay_details_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package braintree
 
 import (

--- a/braintree_test.go
+++ b/braintree_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package braintree
 
 import (

--- a/client_token_integration_test.go
+++ b/client_token_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package braintree
 
 import "testing"

--- a/credit_card_integration_test.go
+++ b/credit_card_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/customer_android_pay_integration_test.go
+++ b/customer_android_pay_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/customer_apple_pay_integration_test.go
+++ b/customer_apple_pay_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/customer_integration_test.go
+++ b/customer_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/customer_paypal_account_integration_test.go
+++ b/customer_paypal_account_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/customer_venmo_account_integration_test.go
+++ b/customer_venmo_account_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/customfields/custom_fields_test.go
+++ b/customfields/custom_fields_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package customfields
 
 import (

--- a/date/date_test.go
+++ b/date/date_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package date
 
 import (

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package braintree
 
 import (

--- a/disbursement_integration_test.go
+++ b/disbursement_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/discount_integration_test.go
+++ b/discount_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/environment_test.go
+++ b/environment_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package braintree
 
 import "testing"

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package braintree
 
 import (

--- a/hmac_test.go
+++ b/hmac_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package braintree
 
 import (

--- a/init_test.go
+++ b/init_test.go
@@ -1,3 +1,5 @@
+// +build unit integration
+
 package braintree
 
 import (

--- a/merchant_account_integration_test.go
+++ b/merchant_account_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/modification_request_test.go
+++ b/modification_request_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package braintree
 
 import (

--- a/payment_method_integration_test.go
+++ b/payment_method_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/paypal_account_integration_test.go
+++ b/paypal_account_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/plan_integration_test.go
+++ b/plan_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/search_test.go
+++ b/search_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package braintree
 
 import (

--- a/settlement_integration_test.go
+++ b/settlement_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/subscription_integration_test.go
+++ b/subscription_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/testing_integration_test.go
+++ b/testing_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/transaction_android_pay_details_integration_test.go
+++ b/transaction_android_pay_details_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/transaction_apple_pay_details_integration_test.go
+++ b/transaction_apple_pay_details_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/transaction_clone_integration_test.go
+++ b/transaction_clone_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/transaction_paypal_details_integration_test.go
+++ b/transaction_paypal_details_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/transaction_venmo_account_details_integration_test.go
+++ b/transaction_venmo_account_details_integration_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package braintree
 
 import (

--- a/webhook_notification_test.go
+++ b/webhook_notification_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package braintree
 
 import (

--- a/webhook_testing_gateway_test.go
+++ b/webhook_testing_gateway_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package braintree
 
 import "testing"

--- a/xmlnil/strip_test.go
+++ b/xmlnil/strip_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package xmlnil
 
 import (


### PR DESCRIPTION
What
===
Add build tags for unit and integration tests, where specifying one of
the build tags will cause only that type of tests to run.

Why
===
The library has a large amount of integration tests and little in the
way of unit tests. We could probably flesh those out and I think
separating them for running locally will help with that effort. CI will
continue to run both together.