### PR TITLE
Add analysis error message for code not gofmt'd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ integration:
 analysis:
 	diff -u <(echo -n) <(go list -f '{{range .TestGoFiles}}{{$$.ImportPath}}/{{.}}{{end}}' ./...) \
 		|| (exit_code=$$?; echo -e '\033[31mTest files should be marked with a unit or integration build tag.\033[0m'; exit $$exit_code)
-	diff -u <(echo -n) <(gofmt -d .)
+	diff -u <(echo -n) <(gofmt -d .) \
+		|| (exit_code=$$?; echo -e '\033[31mRun gofmt to format source files.\033[0m'; exit $$exit_code)
 	go vet ./...
 	go get github.com/kisielk/errcheck && CGO_ENABLED=0 errcheck ./...
 


### PR DESCRIPTION
What
===
Add analysis error message for code not formatted with gofmt.

Why
===
The check existed but it didn't output any meaningful text.