### PR TITLE
Allow TransactionGateway.Search to return more than 50 transactions.

### DIFF
--- a/search.go
+++ b/search.go
@@ -10,9 +10,9 @@ type SearchQuery struct {
 	Fields  []interface{}
 }
 
-type SearchResults struct {
+type searchResults struct {
 	XMLName  string `xml:"search-results"`
-	PageSize string `xml:"page-size"`
+	PageSize int    `xml:"page-size"`
 	Ids      struct {
 		Item []string `xml:"item"`
 	} `xml:"ids"`
@@ -111,4 +111,11 @@ func (s *SearchQuery) AddMultiField(field string) *MultiField {
 	}
 	s.Fields = append(s.Fields, f)
 	return f
+}
+
+func (s *SearchQuery) shallowCopy() *SearchQuery {
+	return &SearchQuery{
+		XMLName: s.XMLName,
+		Fields:  s.Fields[:len(s.Fields):len(s.Fields)],
+	}
 }

--- a/search.go
+++ b/search.go
@@ -20,12 +20,9 @@ func (s *SearchQuery) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return e.EncodeElement(&x, start)
 }
 
-type searchResults struct {
-	XMLName  string `xml:"search-results"`
-	PageSize int    `xml:"page-size"`
-	Ids      struct {
-		Item []string `xml:"item"`
-	} `xml:"ids"`
+type SearchResult struct {
+	PageSize int
+	IDs      []string
 }
 
 type TextField struct {

--- a/search.go
+++ b/search.go
@@ -6,8 +6,18 @@ import (
 )
 
 type SearchQuery struct {
-	XMLName string `xml:"search"`
-	Fields  []interface{}
+	fields     []interface{}
+	fieldIndex map[string]int
+}
+
+func (s *SearchQuery) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	start.Name.Local = "search"
+	x := struct {
+		Fields []interface{}
+	}{
+		Fields: s.fields,
+	}
+	return e.EncodeElement(&x, start)
 }
 
 type searchResults struct {
@@ -86,21 +96,33 @@ type MultiField struct {
 	Items   []string `xml:"item"`
 }
 
+func (s *SearchQuery) addField(fieldName string, field interface{}) {
+	if i, ok := s.fieldIndex[fieldName]; !ok {
+		s.fields = append(s.fields, field)
+		if s.fieldIndex == nil {
+			s.fieldIndex = map[string]int{}
+		}
+		s.fieldIndex[fieldName] = len(s.fields) - 1
+	} else {
+		s.fields[i] = field
+	}
+}
+
 func (s *SearchQuery) AddTextField(field string) *TextField {
 	f := &TextField{XMLName: xml.Name{Local: field}}
-	s.Fields = append(s.Fields, f)
+	s.addField(field, f)
 	return f
 }
 
 func (s *SearchQuery) AddRangeField(field string) *RangeField {
 	f := &RangeField{XMLName: xml.Name{Local: field}}
-	s.Fields = append(s.Fields, f)
+	s.addField(field, f)
 	return f
 }
 
 func (s *SearchQuery) AddTimeField(field string) *TimeField {
 	f := &TimeField{XMLName: xml.Name{Local: field}}
-	s.Fields = append(s.Fields, f)
+	s.addField(field, f)
 	return f
 }
 
@@ -109,13 +131,23 @@ func (s *SearchQuery) AddMultiField(field string) *MultiField {
 		XMLName: xml.Name{Local: field},
 		Type:    "array",
 	}
-	s.Fields = append(s.Fields, f)
+	s.addField(field, f)
 	return f
 }
 
 func (s *SearchQuery) shallowCopy() *SearchQuery {
 	return &SearchQuery{
-		XMLName: s.XMLName,
-		Fields:  s.Fields[:len(s.Fields):len(s.Fields)],
+		fields: func() []interface{} {
+			a := make([]interface{}, len(s.fields))
+			copy(a, s.fields)
+			return a
+		}(),
+		fieldIndex: func() map[string]int {
+			m := map[string]int{}
+			for f, i := range s.fieldIndex {
+				m[f] = i
+			}
+			return m
+		}(),
 	}
 }

--- a/search_test.go
+++ b/search_test.go
@@ -144,7 +144,7 @@ func TestSearchResultUnmarshal(t *testing.T) {
   </ids>
 </search-results>`
 
-	var v SearchResults
+	var v searchResults
 	err := xml.Unmarshal([]byte(xmls), &v)
 	if err != nil {
 		t.Fatal(err)

--- a/search_test.go
+++ b/search_test.go
@@ -132,31 +132,3 @@ func TestSearchXMLEncode(t *testing.T) {
 		t.Fatalf("got %#v, want %#v", xmls, expect)
 	}
 }
-
-func TestSearchResultUnmarshal(t *testing.T) {
-	t.Parallel()
-
-	xmls := `<search-results>
-  <page-size type="integer">50</page-size>
-  <ids type="array">
-      <item>k658ww</item>
-      <item>fd2h96</item>
-  </ids>
-</search-results>`
-
-	var v searchResults
-	err := xml.Unmarshal([]byte(xmls), &v)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(v.Ids.Item) != 2 {
-		t.Fatal(v.Ids)
-	}
-	if x := v.Ids.Item[0]; x != "k658ww" {
-		t.Fatal(x)
-	}
-	if x := v.Ids.Item[1]; x != "fd2h96" {
-		t.Fatal(x)
-	}
-}

--- a/transaction.go
+++ b/transaction.go
@@ -213,19 +213,14 @@ func (r TransactionOptionsPaypalRequest) MarshalXML(e *xml.Encoder, start xml.St
 }
 
 type TransactionSearchResult struct {
-	XMLName string `xml:"search-results"`
-	// CurrentPageNumber is not in the XML response but added manually for backward compatability.
-	CurrentPageNumber int
-	// PageSize indicates the page size for subsequent calls to get transaction detail. There can be more items in the Ids struct than indicated by PageSize.
-	PageSize int `xml:"page-size"`
-	// TotalItems is not in the XML response but added manually for backward compatability
 	TotalItems int
-	// Transactions is not in the XML response, but added in manually.
-	Transactions []*Transaction
-	// Per https://developers.braintreepayments.com/reference/general/searching/search-results/java only 20,000 ids can be returned.
-	Ids struct {
-		Item []string `xml:"item"`
-	} `xml:"ids"`
+	TotalIDs   []string
+
+	CurrentPageNumber int
+	PageSize          int
+	Transactions      []*Transaction
+
+	searchQuery *SearchQuery
 }
 
 type RiskData struct {

--- a/transaction.go
+++ b/transaction.go
@@ -213,11 +213,19 @@ func (r TransactionOptionsPaypalRequest) MarshalXML(e *xml.Encoder, start xml.St
 }
 
 type TransactionSearchResult struct {
-	XMLName           string         `xml:"credit-card-transactions"`
-	CurrentPageNumber int            `xml:"current-page-number"`
-	PageSize          int            `xml:"page-size"`
-	TotalItems        int            `xml:"total-items"`
-	Transactions      []*Transaction `xml:"transaction"`
+	XMLName string `xml:"search-results"`
+	// CurrentPageNumbwer is not in the XML response but added manually for backward compatability
+	CurrentPageNumber int
+	// PageSize indicates the page size for subsequent calls to get transaction detail. There can be more items in the Ids struct than indicated by PageSize.
+	PageSize int `xml:"page-size"`
+	// TotalItems is not in the XML response but added manually for backward compatability
+	TotalItems int
+	// Transactions is not in the XML response, but added in manually.
+	Transactions []*Transaction
+	// Per https://developers.braintreepayments.com/reference/general/searching/search-results/java only 20,000 ids can be returned.
+	Ids struct {
+		Item []string `xml:"item"`
+	} `xml:"ids"`
 }
 
 type RiskData struct {

--- a/transaction.go
+++ b/transaction.go
@@ -214,7 +214,7 @@ func (r TransactionOptionsPaypalRequest) MarshalXML(e *xml.Encoder, start xml.St
 
 type TransactionSearchResult struct {
 	XMLName string `xml:"search-results"`
-	// CurrentPageNumbwer is not in the XML response but added manually for backward compatability
+	// CurrentPageNumber is not in the XML response but added manually for backward compatability.
 	CurrentPageNumber int
 	// PageSize indicates the page size for subsequent calls to get transaction detail. There can be more items in the Ids struct than indicated by PageSize.
 	PageSize int `xml:"page-size"`

--- a/transaction.go
+++ b/transaction.go
@@ -220,8 +220,6 @@ type TransactionSearchResult struct {
 	CurrentPageNumber int
 	PageSize          int
 	Transactions      []*Transaction
-
-	searchQuery *SearchQuery
 }
 
 type RiskData struct {

--- a/transaction_gateway.go
+++ b/transaction_gateway.go
@@ -154,7 +154,7 @@ func (g *TransactionGateway) Find(ctx context.Context, id string) (*Transaction,
 }
 
 // Search finds all transactions matching the search query.
-// Per https://developers.braintreepayments.com/reference/general/searching/search-results/java a max of 20,000 results can be returned.
+// Per https://developers.braintreepayments.com/reference/general/searching/search-results a max of 20,000 results can be returned.
 func (g *TransactionGateway) Search(ctx context.Context, query *SearchQuery) (*TransactionSearchResult, error) {
 	// Get the ids of all transactions that match the search criteria.
 	resp, err := g.execute(ctx, "POST", "transactions/advanced_search_ids", query)

--- a/transaction_gateway.go
+++ b/transaction_gateway.go
@@ -65,7 +65,7 @@ func (g *TransactionGateway) Settle(ctx context.Context, id string) (*Transactio
 
 // Void voids the transaction with the specified id if it has a status of authorized or
 // submitted_for_settlement. When the transaction is voided Braintree will do an authorization
-// reversal if possible so that the customer won’t have a pending charge on their card
+// reversal if possible so that the customer won't have a pending charge on their card
 func (g *TransactionGateway) Void(ctx context.Context, id string) (*Transaction, error) {
 	resp, err := g.execute(ctx, "PUT", "transactions/"+id+"/void", nil)
 	if err != nil {
@@ -154,17 +154,51 @@ func (g *TransactionGateway) Find(ctx context.Context, id string) (*Transaction,
 }
 
 // Search finds all transactions matching the search query.
+// Per https://developers.braintreepayments.com/reference/general/searching/search-results/java a max of 20,000 results can be returned.
 func (g *TransactionGateway) Search(ctx context.Context, query *SearchQuery) (*TransactionSearchResult, error) {
-	resp, err := g.execute(ctx, "POST", "transactions/advanced_search", query)
+	// Get the ids of all transactions that match the search criteria.
+	resp, err := g.execute(ctx, "POST", "transactions/advanced_search_ids", query)
 	if err != nil {
 		return nil, err
 	}
-	var v TransactionSearchResult
-	err = xml.Unmarshal(resp.Body, &v)
+	v := new(TransactionSearchResult)
+	err = xml.Unmarshal(resp.Body, v)
 	if err != nil {
 		return nil, err
 	}
-	return &v, err
+
+	// Get transaction details and add them to the TransactionSearchResult. Only v.PageSize transactions can be fetched at one time.
+	totalItems := len(v.Ids.Item)
+	txs, err := fetchTransactions(ctx, g, query, v.Ids.Item, totalItems, v.PageSize)
+	if err != nil {
+		return nil, err
+	}
+	v.Transactions = txs
+
+	// Add data for backward compatibility. CurrnetPageNumber is pretty meaningless though.
+	v.CurrentPageNumber = 1
+	v.TotalItems = totalItems
+
+	return v, err
+}
+
+func fetchTransactions(ctx context.Context, g executer, query *SearchQuery, txIds []string, totalItems int, pageSize int) ([]*Transaction, error) {
+	txs := make([]*Transaction, 0)
+	ids := query.AddMultiField("ids")
+	for i := 0; i < totalItems; i += pageSize {
+		ids.Items = txIds[i:min(i+pageSize, totalItems)]
+		res, fetchError := fetchTransactionPage(ctx, g, query)
+		if fetchError != nil {
+			return nil, fetchError
+		}
+		for _, tx := range res.Transactions {
+			txs = append(txs, tx)
+		}
+	}
+	if len(txs) != totalItems {
+		return nil, fmt.Errorf("Unexpected number of transactions. Got %v, want %v.", len(txs), totalItems)
+	}
+	return txs, nil
 }
 
 type testOperationPerformedInProductionError struct {
@@ -173,4 +207,39 @@ type testOperationPerformedInProductionError struct {
 
 func (e *testOperationPerformedInProductionError) Error() string {
 	return fmt.Sprint("Operation not allowed in production environment")
+}
+
+// FetchTransactionPage returns a page of transactions including details for a given query.
+func fetchTransactionPage(ctx context.Context, g executer, query *SearchQuery) (*transactionDetailSearchResult, error) {
+	resp, err := g.execute(ctx, "POST", "transactions/advanced_search", query)
+	if err != nil {
+		return nil, err
+	}
+	v := new(transactionDetailSearchResult)
+	err = xml.Unmarshal(resp.Body, v)
+	if err != nil {
+		return nil, err
+	}
+	return v, err
+}
+
+func min(a, b int) int {
+	if a <= b {
+		return a
+	}
+	return b
+}
+
+// TransactionDetailSearchResult is used to fetch a page of transactions with all details.
+type transactionDetailSearchResult struct {
+	XMLName           string         `xml:"credit-card-transactions"`
+	CurrentPageNumber int            `xml:"current-page-number"`
+	PageSize          int            `xml:"page-size"`
+	TotalItems        int            `xml:"total-items"`
+	Transactions      []*Transaction `xml:"transaction"`
+}
+
+// Executer provides an execute method.
+type executer interface {
+	execute(ctx context.Context, method, path string, xmlObj interface{}) (*Response, error)
 }

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -237,7 +237,7 @@ func TestTransactionSearchPagination(t *testing.T) {
 			}
 		}
 
-		results, err = txg.SearchNext(ctx, results)
+		results, err = txg.SearchNext(ctx, query, results)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -83,7 +83,7 @@ func TestTransactionSearchIDs(t *testing.T) {
 		return txg.Create(ctx, &TransactionRequest{
 			Type:   "sale",
 			Amount: amount,
-			Customer: &Customer{
+			Customer: &CustomerRequest{
 				FirstName: customerName,
 			},
 			CreditCard: &CreditCard{
@@ -193,7 +193,7 @@ func TestTransactionSearchPagination(t *testing.T) {
 		tx, err := txg.Create(ctx, &TransactionRequest{
 			Type:   "sale",
 			Amount: randomAmount(),
-			Customer: &Customer{
+			Customer: &CustomerRequest{
 				FirstName: prefix + unique,
 			},
 			CreditCard: &CreditCard{


### PR DESCRIPTION
What
===
Fetch the Ids for all search results then fetch the transaction details
one page at a time. TransactionGateway.Search should be backwards
compatible. The only difference being additional fields in
TransactionSearchResult and more than 50 transactions in the
Transaction field.

Per
https://developers.braintreepayments.com/reference/general/searching/search-results/java
up to 20,000 transactions can be returned.

Much of this work is based on the work by @rkulla:
https://github.com/dailyburn/braintree-go/commit/d44aa131caad6055c0e4aac2f3a24450aa818c63

Why
===
The Braintree API only returns 50 transactions with all details at one
time. To fetch all results from a query, the transaction ids must be
fetched first, then the details can be fetched by specifying 50 ids per
API call. This issue was first raised in #112.