### PR TITLE
Setup default transport with TLS 1.2 requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+BACKWARDS INCOMPATIBILITES:
+
+* Drop support for versions of TLS prior to TLS 1.2.
+
 ## 0.17.0 (January 5th, 2018)
 
 IMPROVEMENTS:

--- a/braintree.go
+++ b/braintree.go
@@ -23,9 +23,8 @@ const (
 const defaultTimeout = time.Second * 60
 
 var (
-	// defaultTransport uses the very same configuration as
-	// http.DefaultTransport with the addition of the minimum requirement
-	// for TLS 1.2
+	// defaultTransport uses the same configuration as http.DefaultTransport
+	// with the addition of the minimum requirement for TLS 1.2
 	defaultTransport = &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{

--- a/braintree.go
+++ b/braintree.go
@@ -3,10 +3,12 @@ package braintree
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/xml"
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"time"
 )
@@ -20,7 +22,30 @@ const (
 
 const defaultTimeout = time.Second * 60
 
-var defaultClient = &http.Client{Timeout: defaultTimeout}
+var (
+	// defaultTransport uses the very same configuration as
+	// http.DefaultTransport with the addition of the minimum requirement
+	// for TLS 1.2
+	defaultTransport = &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		},
+	}
+	defaultClient = &http.Client{
+		Timeout:   defaultTimeout,
+		Transport: defaultTransport,
+	}
+)
 
 // New creates a Braintree with API Keys.
 func New(env Environment, merchId, pubKey, privKey string) *Braintree {


### PR DESCRIPTION
https://github.com/lionelbarrow/braintree-go/issues/207