### PR TITLE
Add go1.10 to build and README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ install:
 jobs:
   include:
     - stage: analysis
-      go: 1.10
+      go: "1.10"
       script: make analysis
 
     - stage: test
-      go: 1.10
+      go: "1.10"
       script: make test
 
     - stage: test
@@ -27,7 +27,7 @@ jobs:
       script: make test
 
     - stage: analysis-is-backward-compatible-with-master
-      go: 1.10
+      go: "1.10"
       script: make analysis-is-backward-compatible-with-master
 
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,12 @@ install:
 jobs:
   include:
     - stage: analysis
-      go: 1.9
+      go: 1.10
       script: make analysis
+
+    - stage: test
+      go: 1.10
+      script: make test
 
     - stage: test
       go: 1.9
@@ -23,7 +27,7 @@ jobs:
       script: make test
 
     - stage: analysis-is-backward-compatible-with-master
-      go: 1.9
+      go: 1.10
       script: make analysis-is-backward-compatible-with-master
 
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The usual. `go get github.com/lionelbarrow/braintree-go`
 * 1.7
 * 1.8
 * 1.9
+* 1.10
 
 ### Documentation
 


### PR DESCRIPTION
What
===
Add Go 1.10 to build and README.

Why
===
Go 1.10 was released today.
https://blog.golang.org/go1.10