### PR TITLE
Add AddressRequest

### DIFF
--- a/address.go
+++ b/address.go
@@ -7,22 +7,38 @@ import (
 
 type Address struct {
 	XMLName            xml.Name
-	Id                 string     `xml:"id,omitempty"`
-	CustomerId         string     `xml:"customer-id,omitempty"`
-	FirstName          string     `xml:"first-name,omitempty"`
-	LastName           string     `xml:"last-name,omitempty"`
-	Company            string     `xml:"company,omitempty"`
-	StreetAddress      string     `xml:"street-address,omitempty"`
-	ExtendedAddress    string     `xml:"extended-address,omitempty"`
-	Locality           string     `xml:"locality,omitempty"`
-	Region             string     `xml:"region,omitempty"`
-	PostalCode         string     `xml:"postal-code,omitempty"`
-	CountryCodeAlpha2  string     `xml:"country-code-alpha2,omitempty"`
-	CountryCodeAlpha3  string     `xml:"country-code-alpha3,omitempty"`
-	CountryCodeNumeric string     `xml:"country-code-numeric,omitempty"`
-	CountryName        string     `xml:"country-name,omitempty"`
-	CreatedAt          *time.Time `xml:"created-at,omitempty"`
-	UpdatedAt          *time.Time `xml:"updated-at,omitempty"`
+	Id                 string     `xml:"id"`
+	CustomerId         string     `xml:"customer-id"`
+	FirstName          string     `xml:"first-name"`
+	LastName           string     `xml:"last-name"`
+	Company            string     `xml:"company"`
+	StreetAddress      string     `xml:"street-address"`
+	ExtendedAddress    string     `xml:"extended-address"`
+	Locality           string     `xml:"locality"`
+	Region             string     `xml:"region"`
+	PostalCode         string     `xml:"postal-code"`
+	CountryCodeAlpha2  string     `xml:"country-code-alpha2"`
+	CountryCodeAlpha3  string     `xml:"country-code-alpha3"`
+	CountryCodeNumeric string     `xml:"country-code-numeric"`
+	CountryName        string     `xml:"country-name"`
+	CreatedAt          *time.Time `xml:"created-at"`
+	UpdatedAt          *time.Time `xml:"updated-at"`
+}
+
+type AddressRequest struct {
+	XMLName            xml.Name `xml:"address"`
+	FirstName          string   `xml:"first-name,omitempty"`
+	LastName           string   `xml:"last-name,omitempty"`
+	Company            string   `xml:"company,omitempty"`
+	StreetAddress      string   `xml:"street-address,omitempty"`
+	ExtendedAddress    string   `xml:"extended-address,omitempty"`
+	Locality           string   `xml:"locality,omitempty"`
+	Region             string   `xml:"region,omitempty"`
+	PostalCode         string   `xml:"postal-code,omitempty"`
+	CountryCodeAlpha2  string   `xml:"country-code-alpha2,omitempty"`
+	CountryCodeAlpha3  string   `xml:"country-code-alpha3,omitempty"`
+	CountryCodeNumeric string   `xml:"country-code-numeric,omitempty"`
+	CountryName        string   `xml:"country-name,omitempty"`
 }
 
 type Addresses struct {

--- a/address.go
+++ b/address.go
@@ -7,22 +7,22 @@ import (
 
 type Address struct {
 	XMLName            xml.Name
-	Id                 string     `xml:"id"`
-	CustomerId         string     `xml:"customer-id"`
-	FirstName          string     `xml:"first-name"`
-	LastName           string     `xml:"last-name"`
-	Company            string     `xml:"company"`
-	StreetAddress      string     `xml:"street-address"`
-	ExtendedAddress    string     `xml:"extended-address"`
-	Locality           string     `xml:"locality"`
-	Region             string     `xml:"region"`
-	PostalCode         string     `xml:"postal-code"`
-	CountryCodeAlpha2  string     `xml:"country-code-alpha2"`
-	CountryCodeAlpha3  string     `xml:"country-code-alpha3"`
-	CountryCodeNumeric string     `xml:"country-code-numeric"`
-	CountryName        string     `xml:"country-name"`
-	CreatedAt          *time.Time `xml:"created-at"`
-	UpdatedAt          *time.Time `xml:"updated-at"`
+	Id                 string     `xml:"id,omitempty"`
+	CustomerId         string     `xml:"customer-id,omitempty"`
+	FirstName          string     `xml:"first-name,omitempty"`
+	LastName           string     `xml:"last-name,omitempty"`
+	Company            string     `xml:"company,omitempty"`
+	StreetAddress      string     `xml:"street-address,omitempty"`
+	ExtendedAddress    string     `xml:"extended-address,omitempty"`
+	Locality           string     `xml:"locality,omitempty"`
+	Region             string     `xml:"region,omitempty"`
+	PostalCode         string     `xml:"postal-code,omitempty"`
+	CountryCodeAlpha2  string     `xml:"country-code-alpha2,omitempty"`
+	CountryCodeAlpha3  string     `xml:"country-code-alpha3,omitempty"`
+	CountryCodeNumeric string     `xml:"country-code-numeric,omitempty"`
+	CountryName        string     `xml:"country-name,omitempty"`
+	CreatedAt          *time.Time `xml:"created-at,omitempty"`
+	UpdatedAt          *time.Time `xml:"updated-at,omitempty"`
 }
 
 type AddressRequest struct {

--- a/address_gateway.go
+++ b/address_gateway.go
@@ -2,7 +2,6 @@ package braintree
 
 import (
 	"context"
-	"encoding/xml"
 )
 
 type AddressGateway struct {
@@ -10,13 +9,8 @@ type AddressGateway struct {
 }
 
 // Create creates a new address for the specified customer id.
-func (g *AddressGateway) Create(ctx context.Context, a *Address) (*Address, error) {
-	// Copy address so that field sanitation won't affect original
-	var cp Address = *a
-	cp.CustomerId = ""
-	cp.XMLName = xml.Name{Local: "address"}
-
-	resp, err := g.execute(ctx, "POST", "customers/"+a.CustomerId+"/addresses", &cp)
+func (g *AddressGateway) Create(ctx context.Context, customerID string, a *AddressRequest) (*Address, error) {
+	resp, err := g.execute(ctx, "POST", "customers/"+customerID+"/addresses", &a)
 	if err != nil {
 		return nil, err
 	}

--- a/address_integration_test.go
+++ b/address_integration_test.go
@@ -23,8 +23,7 @@ func TestAddress(t *testing.T) {
 		t.Fatal("invalid customer id")
 	}
 
-	addr := &Address{
-		CustomerId:         customer.Id,
+	addr := &AddressRequest{
 		FirstName:          "Jenna",
 		LastName:           "Smith",
 		Company:            "Braintree",
@@ -39,7 +38,7 @@ func TestAddress(t *testing.T) {
 		CountryName:        "United States of America",
 	}
 
-	addr2, err := testGateway.Address().Create(ctx, addr)
+	addr2, err := testGateway.Address().Create(ctx, customer.Id, addr)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
What
===
Add AddressRequest and change the AddressGateway Create function to use
the same patterns found in the official Braintree SDKs.

Why
===
Not all the fields that are returned for an address are valid to pass to
Braintree when creating and updating addresses. The official Braintree
SDKs, and some of the other gateways in this SDK, have moved to the
model of separating requests and responses. This is part of the
continuing effort to bring this SDK inline with the official SDKs.

Notes
===
This contains two breaking changes. The object used to hold the
parameters for the AddressGateway's Create function has changed from
Address to AddressRequest, and the Customer ID for the request has been
moved out to be a function parameter. This is to be consistent with the
other SDKs and so that the request struct only contains fields that can
be passed to Braintree which makes its use clearer.

Related
===
#209 