### PR TITLE
Add CustomerRequest

### DIFF
--- a/address_integration_test.go
+++ b/address_integration_test.go
@@ -12,7 +12,7 @@ func TestAddress(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{
 		FirstName: "Jenna",
 		LastName:  "Smith",
 	})

--- a/client_token_integration_test.go
+++ b/client_token_integration_test.go
@@ -28,7 +28,7 @@ func TestClientTokenWithCustomer(t *testing.T) {
 
 	ctx := context.Background()
 
-	customerRequest := &Customer{FirstName: "Lionel"}
+	customerRequest := &CustomerRequest{FirstName: "Lionel"}
 
 	customer, err := testGateway.Customer().Create(ctx, customerRequest)
 	if err != nil {

--- a/credit_card_integration_test.go
+++ b/credit_card_integration_test.go
@@ -14,7 +14,7 @@ func TestCreditCard(t *testing.T) {
 
 	ctx := context.Background()
 
-	cust, err := testGateway.Customer().Create(ctx, &Customer{})
+	cust, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +74,7 @@ func TestCreditCardFailedAutoVerification(t *testing.T) {
 
 	ctx := context.Background()
 
-	cust, err := testGateway.Customer().Create(ctx, &Customer{})
+	cust, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,7 +100,7 @@ func TestCreditCardForceNotVerified(t *testing.T) {
 
 	ctx := context.Background()
 
-	cust, err := testGateway.Customer().Create(ctx, &Customer{})
+	cust, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +125,7 @@ func TestCreateCreditCardWithExpirationMonthAndYear(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{})
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,7 +170,7 @@ func TestFindCreditCard(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{})
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,7 +224,7 @@ func TestSaveCreditCardWithVenmoSDKPaymentMethodCode(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{})
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -245,7 +245,7 @@ func TestSaveCreditCardWithVenmoSDKSession(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{})
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/customer.go
+++ b/customer.go
@@ -6,22 +6,22 @@ import (
 
 type Customer struct {
 	XMLName            string                    `xml:"customer"`
-	Id                 string                    `xml:"id,omitempty"`
-	FirstName          string                    `xml:"first-name,omitempty"`
-	LastName           string                    `xml:"last-name,omitempty"`
-	Company            string                    `xml:"company,omitempty"`
-	Email              string                    `xml:"email,omitempty"`
-	Phone              string                    `xml:"phone,omitempty"`
-	Fax                string                    `xml:"fax,omitempty"`
-	Website            string                    `xml:"website,omitempty"`
-	CustomFields       customfields.CustomFields `xml:"custom-fields,omitempty"`
-	CreditCard         *CreditCard               `xml:"credit-card,omitempty"`
-	CreditCards        *CreditCards              `xml:"credit-cards,omitempty"`
-	PayPalAccounts     *PayPalAccounts           `xml:"paypal-accounts,omitempty"`
-	VenmoAccounts      *VenmoAccounts            `xml:"venmo-accounts,omitempty"`
-	AndroidPayCards    *AndroidPayCards          `xml:"android-pay-cards,omitempty"`
-	ApplePayCards      *ApplePayCards            `xml:"apple-pay-cards,omitempty"`
-	PaymentMethodNonce string                    `xml:"payment-method-nonce,omitempty"`
+	Id                 string                    `xml:"id"`
+	FirstName          string                    `xml:"first-name"`
+	LastName           string                    `xml:"last-name"`
+	Company            string                    `xml:"company"`
+	Email              string                    `xml:"email"`
+	Phone              string                    `xml:"phone"`
+	Fax                string                    `xml:"fax"`
+	Website            string                    `xml:"website"`
+	CustomFields       customfields.CustomFields `xml:"custom-fields"`
+	CreditCard         *CreditCard               `xml:"credit-card"`
+	CreditCards        *CreditCards              `xml:"credit-cards"`
+	PayPalAccounts     *PayPalAccounts           `xml:"paypal-accounts"`
+	VenmoAccounts      *VenmoAccounts            `xml:"venmo-accounts"`
+	AndroidPayCards    *AndroidPayCards          `xml:"android-pay-cards"`
+	ApplePayCards      *ApplePayCards            `xml:"apple-pay-cards"`
+	PaymentMethodNonce string                    `xml:"payment-method-nonce"`
 }
 
 // PaymentMethods returns a slice of all PaymentMethods this customer has
@@ -53,6 +53,21 @@ func (c *Customer) DefaultPaymentMethod() PaymentMethod {
 		}
 	}
 	return nil
+}
+
+type CustomerRequest struct {
+	XMLName            string                    `xml:"customer"`
+	ID                 string                    `xml:"id,omitempty"`
+	FirstName          string                    `xml:"first-name,omitempty"`
+	LastName           string                    `xml:"last-name,omitempty"`
+	Company            string                    `xml:"company,omitempty"`
+	Email              string                    `xml:"email,omitempty"`
+	Phone              string                    `xml:"phone,omitempty"`
+	Fax                string                    `xml:"fax,omitempty"`
+	Website            string                    `xml:"website,omitempty"`
+	CustomFields       customfields.CustomFields `xml:"custom-fields,omitempty"`
+	CreditCard         *CreditCard               `xml:"credit-card,omitempty"`
+	PaymentMethodNonce string                    `xml:"payment-method-nonce,omitempty"`
 }
 
 type CustomerSearchResult struct {

--- a/customer_android_pay_integration_test.go
+++ b/customer_android_pay_integration_test.go
@@ -13,7 +13,7 @@ func TestCustomerAndroidPayCard(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{})
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/customer_apple_pay_integration_test.go
+++ b/customer_apple_pay_integration_test.go
@@ -13,7 +13,7 @@ func TestCustomerApplePayCard(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{})
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/customer_gateway.go
+++ b/customer_gateway.go
@@ -11,7 +11,7 @@ type CustomerGateway struct {
 
 // Create creates a new customer from the passed in customer object.
 // If no Id is set, Braintree will assign one.
-func (g *CustomerGateway) Create(ctx context.Context, c *Customer) (*Customer, error) {
+func (g *CustomerGateway) Create(ctx context.Context, c *CustomerRequest) (*Customer, error) {
 	resp, err := g.execute(ctx, "POST", "customers", c)
 	if err != nil {
 		return nil, err
@@ -25,8 +25,8 @@ func (g *CustomerGateway) Create(ctx context.Context, c *Customer) (*Customer, e
 
 // Update updates any field that is set in the passed customer object.
 // The Id field is mandatory.
-func (g *CustomerGateway) Update(ctx context.Context, c *Customer) (*Customer, error) {
-	resp, err := g.execute(ctx, "PUT", "customers/"+c.Id, c)
+func (g *CustomerGateway) Update(ctx context.Context, c *CustomerRequest) (*Customer, error) {
+	resp, err := g.execute(ctx, "PUT", "customers/"+c.ID, c)
 	if err != nil {
 		return nil, err
 	}

--- a/customer_integration_test.go
+++ b/customer_integration_test.go
@@ -17,7 +17,7 @@ func TestCustomer(t *testing.T) {
 
 	ctx := context.Background()
 
-	oc := &Customer{
+	oc := &CustomerRequest{
 		FirstName: "Lionel",
 		LastName:  "Barrow",
 		Company:   "Braintree",
@@ -64,8 +64,8 @@ func TestCustomer(t *testing.T) {
 	// Update
 	unique := testhelpers.RandomString()
 	newFirstName := "John" + unique
-	c2, err := testGateway.Customer().Update(ctx, &Customer{
-		Id:        customer.Id,
+	c2, err := testGateway.Customer().Update(ctx, &CustomerRequest{
+		ID:        customer.Id,
 		FirstName: newFirstName,
 	})
 
@@ -136,7 +136,7 @@ func TestCustomerWithCustomFields(t *testing.T) {
 		"custom_field_1": "custom value",
 	}
 
-	c := &Customer{
+	c := &CustomerRequest{
 		CustomFields: customFields,
 	}
 
@@ -164,7 +164,7 @@ func TestCustomerPaymentMethods(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{})
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +204,7 @@ func TestCustomerDefaultPaymentMethod(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{})
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -239,7 +239,7 @@ func TestCustomerDefaultPaymentMethodManuallySet(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{})
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -283,7 +283,7 @@ func TestCustomerPaymentMethodNonce(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{PaymentMethodNonce: FakeNonceTransactable})
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{PaymentMethodNonce: FakeNonceTransactable})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/customer_paypal_account_integration_test.go
+++ b/customer_paypal_account_integration_test.go
@@ -13,7 +13,7 @@ func TestCustomerPayPalAccount(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{})
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/customer_venmo_account_integration_test.go
+++ b/customer_venmo_account_integration_test.go
@@ -13,7 +13,7 @@ func TestCustomerVenmoAccount(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{})
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/examples/subscription/server.go
+++ b/examples/subscription/server.go
@@ -57,10 +57,10 @@ func main() {
 		}
 		// You can later search for the user by his ID
 		// customer, err := bt.Customer().Find("CustomerID")
-		customer, err := bt.Customer().Create(ctx, &braintree.Customer{
+		customer, err := bt.Customer().Create(ctx, &braintree.CustomerRequest{
 			// You can leave it empty, but, if you've got a user system, I recommend using the user's ID as the client ID
 			// Or, createa a row for Braintree's customer ID
-			Id: "<CustomerID>",
+			ID: "<CustomerID>",
 		})
 		if err != nil {
 			log.Fatal(err)

--- a/payment_method_integration_test.go
+++ b/payment_method_integration_test.go
@@ -17,7 +17,7 @@ func TestPaymentMethod(t *testing.T) {
 
 	ctx := context.Background()
 
-	cust, err := testGateway.Customer().Create(ctx, &Customer{})
+	cust, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestPaymentMethodFailedAutoVerification(t *testing.T) {
 
 	ctx := context.Background()
 
-	cust, err := testGateway.Customer().Create(ctx, &Customer{})
+	cust, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +140,7 @@ func TestPaymentMethodForceNotVerified(t *testing.T) {
 
 	ctx := context.Background()
 
-	cust, err := testGateway.Customer().Create(ctx, &Customer{})
+	cust, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/paypal_account_integration_test.go
+++ b/paypal_account_integration_test.go
@@ -12,7 +12,7 @@ func TestPayPalAccount(t *testing.T) {
 
 	ctx := context.Background()
 
-	cust, err := testGateway.Customer().Create(ctx, &Customer{})
+	cust, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/subscription_integration_test.go
+++ b/subscription_integration_test.go
@@ -17,7 +17,7 @@ func TestSubscriptionSimple(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{})
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +92,7 @@ func TestSubscriptionAllFieldsWithBillingDayOfMonth(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{})
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -206,7 +206,7 @@ func TestSubscriptionAllFieldsWithBillingDayOfMonthNeverExpires(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{})
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -320,7 +320,7 @@ func TestSubscriptionAllFieldsWithFirstBillingDate(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{})
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -440,7 +440,7 @@ func TestSubscriptionAllFieldsWithFirstBillingDateNeverExpires(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{})
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -558,7 +558,7 @@ func TestSubscriptionAllFieldsWithTrialPeriod(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{})
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -681,7 +681,7 @@ func TestSubscriptionAllFieldsWithTrialPeriodNeverExpires(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{})
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -804,7 +804,7 @@ func TestSubscriptionModifications(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{})
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -945,7 +945,7 @@ func TestSubscriptionTransactions(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{})
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/transaction.go
+++ b/transaction.go
@@ -87,7 +87,7 @@ type TransactionRequest struct {
 	MerchantAccountId   string                    `xml:"merchant-account-id,omitempty"`
 	PlanId              string                    `xml:"plan-id,omitempty"`
 	CreditCard          *CreditCard               `xml:"credit-card,omitempty"`
-	Customer            *Customer                 `xml:"customer,omitempty"`
+	Customer            *CustomerRequest          `xml:"customer,omitempty"`
 	BillingAddress      *Address                  `xml:"billing,omitempty"`
 	ShippingAddress     *Address                  `xml:"shipping,omitempty"`
 	TaxAmount           *Decimal                  `xml:"tax-amount,omitempty"`

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -82,7 +82,7 @@ func TestTransactionSearch(t *testing.T) {
 		_, err := txg.Create(ctx, &TransactionRequest{
 			Type:   "sale",
 			Amount: amount,
-			Customer: &Customer{
+			Customer: &CustomerRequest{
 				FirstName: customerName,
 			},
 			CreditCard: &CreditCard{
@@ -133,7 +133,7 @@ func TestTransactionSearchTime(t *testing.T) {
 		_, err := txg.Create(ctx, &TransactionRequest{
 			Type:   "sale",
 			Amount: amount,
-			Customer: &Customer{
+			Customer: &CustomerRequest{
 				FirstName: customerName,
 			},
 			CreditCard: &CreditCard{
@@ -530,7 +530,7 @@ func TestTransactionPaypalFields(t *testing.T) {
 	subData := make(map[string]string)
 	subData["faz"] = "bar"
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{})
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -633,7 +633,7 @@ func TestAllTransactionFields(t *testing.T) {
 			ExpirationDate: "05/14",
 			CVV:            "100",
 		},
-		Customer: &Customer{
+		Customer: &CustomerRequest{
 			FirstName: "Lionel",
 		},
 		BillingAddress: &Address{
@@ -717,7 +717,7 @@ func TestAllTransactionFields(t *testing.T) {
 		t.Fatalf("expected CreditCard.Token to be equal, but %s was not %s", tx2.CreditCard.Token, tx.CreditCard.Token)
 	}
 	if tx2.Customer.Id == "" {
-		t.Fatalf("expected Customer.Id to be equal, but %s was not %s", tx2.Customer.Id, tx.Customer.Id)
+		t.Fatalf("expected Customer.Id to be equal, but %s was not %s", tx2.Customer.Id, tx.Customer.ID)
 	}
 	if tx2.Status != TransactionStatusSubmittedForSettlement {
 		t.Fatalf("expected tx2.Status to be %s, but got %s", TransactionStatusSubmittedForSettlement, tx2.Status)
@@ -781,7 +781,7 @@ func TestTransactionCreateFromPaymentMethodCode(t *testing.T) {
 
 	ctx := context.Background()
 
-	customer, err := testGateway.Customer().Create(ctx, &Customer{
+	customer, err := testGateway.Customer().Create(ctx, &CustomerRequest{
 		CreditCard: &CreditCard{
 			Number:         testCreditCards["discover"].Number,
 			ExpirationDate: "05/14",


### PR DESCRIPTION
What
===
Add CustomerRequest and change the CustomerGateway Create function to use
the same patterns found in the official Braintree SDKs.

Why
===
Not all the fields that are returned for a customer are valid to pass to
Braintree when creating and updating customers. The official Braintree
SDKs, and some of the other gateways in this SDK, have moved to the
model of separating requests and responses. This is part of the
continuing effort to bring this SDK inline with the official SDKs.

Notes
===
This contains a breaking change. The object used to hold the parameters
for the CustomerGateway's Create function has changed from Customer to
CustomerRequest. This is to be consistent with the other SDKs and so
that the request struct only contains fields that can be passed to
Braintree which makes its use clearer.

Related
===
#209 