### PR TITLE
transaction source and recurring added

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -7,11 +7,7 @@ import (
 	"github.com/lionelbarrow/braintree-go/customfields"
 )
 
-type (
-	TransactionStatus string
-
-	TransactionSource string
-)
+type TransactionStatus string
 
 const (
 	TransactionStatusAuthorizationExpired   TransactionStatus = "authorization_expired"
@@ -28,7 +24,11 @@ const (
 	TransactionStatusSubmittedForSettlement TransactionStatus = "submitted_for_settlement"
 	TransactionStatusVoided                 TransactionStatus = "voided"
 	TransactionStatusUnrecognized           TransactionStatus = "unrecognized"
+)
 
+type TransactionSource string
+
+const (
 	TransactionSourceRecurringFirst TransactionSource = "recurring_first"
 	TransactionSourceRecurring      TransactionSource = "recurring"
 	TransactionSourceMOTO           TransactionSource = "moto"

--- a/transaction.go
+++ b/transaction.go
@@ -9,6 +9,7 @@ import (
 
 type (
 	TransactionStatus string
+
 	TransactionSource string
 )
 
@@ -30,8 +31,8 @@ const (
 
 	TransactionSourceRecurringFirst TransactionSource = "recurring_first"
 	TransactionSourceRecurring      TransactionSource = "recurring"
-	TransactionMoto                 TransactionSource = "moto"
-	TransctionMerchant              TransactionSource = "merchant"
+	TransactionSourceMOTO           TransactionSource = "moto"
+	TransactionSourceMerchant       TransactionSource = "merchant"
 )
 
 type Transaction struct {

--- a/transaction.go
+++ b/transaction.go
@@ -111,7 +111,6 @@ type TransactionRequest struct {
 	CustomFields        customfields.CustomFields `xml:"custom-fields,omitempty"`
 	PurchaseOrderNumber string                    `xml:"purchase-order-number,omitempty"`
 	TransactionSource   TransactionSource         `xml:"transaction-source,omitempty"`
-	Recurring           bool                      `xml:"recurring,omitempty"`
 }
 
 func (t *Transaction) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {

--- a/transaction.go
+++ b/transaction.go
@@ -7,7 +7,10 @@ import (
 	"github.com/lionelbarrow/braintree-go/customfields"
 )
 
-type TransactionStatus string
+type (
+	TransactionStatus string
+	TransactionSource string
+)
 
 const (
 	TransactionStatusAuthorizationExpired   TransactionStatus = "authorization_expired"
@@ -24,6 +27,11 @@ const (
 	TransactionStatusSubmittedForSettlement TransactionStatus = "submitted_for_settlement"
 	TransactionStatusVoided                 TransactionStatus = "voided"
 	TransactionStatusUnrecognized           TransactionStatus = "unrecognized"
+
+	TransactionSourceRecurringFirst TransactionSource = "recurring_first"
+	TransactionSourceRecurring      TransactionSource = "recurring"
+	TransactionMoto                 TransactionSource = "moto"
+	TransctionMerchant              TransactionSource = "merchant"
 )
 
 type Transaction struct {
@@ -101,6 +109,8 @@ type TransactionRequest struct {
 	Channel             string                    `xml:"channel,omitempty"`
 	CustomFields        customfields.CustomFields `xml:"custom-fields,omitempty"`
 	PurchaseOrderNumber string                    `xml:"purchase-order-number,omitempty"`
+	TransactionSource   TransactionSource         `xml:"transaction-source,omitempty"`
+	Recurring           bool                      `xml:"recurring,omitempty"`
 }
 
 func (t *Transaction) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -786,6 +786,7 @@ func TestAllTransactionFields(t *testing.T) {
 			ExpirationDate: "05/14",
 			CVV:            "100",
 		},
+		TransactionSource: TransactionSourceMOTO,
 		Customer: &CustomerRequest{
 			FirstName: "Lionel",
 		},


### PR DESCRIPTION
This PR got the purpose to add to the TransactionRequest fields 
- Recurring (false/true) according to the Braintree assistance sending it during recurring payment is increasing the rating from the provider and processed faste
- TransactionSource added to enforce Recurring it will override it giving more specific recurring types

