### PR TITLE
Rewrite validation errors handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.19.0 (Unreleased)
+
+BACKWARDS INCOMPATIBILITES:
+
+* Rewrite error handling and interfaces. See #222 for details.
+
 ## 0.18.0 (March 2nd, 2018)
 
 BACKWARDS INCOMPATIBILITES:

--- a/errors.go
+++ b/errors.go
@@ -1,19 +1,38 @@
 package braintree
 
-import "strings"
-
-type errorGroup interface {
-	For(string) errorGroup
-	On(string) []FieldError
-}
+import (
+	"bytes"
+	"encoding/xml"
+	"io"
+	"strconv"
+	"unicode"
+)
 
 type BraintreeError struct {
-	statusCode      int
-	XMLName         string           `xml:"api-error-response"`
-	Errors          responseErrors   `xml:"errors"`
-	ErrorMessage    string           `xml:"message"`
-	MerchantAccount *MerchantAccount `xml:",omitempty"`
-	Transaction     Transaction      `xml:"transaction"`
+	statusCode int
+	errors     ValidationErrors
+
+	ErrorMessage    string
+	MerchantAccount *MerchantAccount
+	Transaction     *Transaction
+}
+
+func (e *BraintreeError) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var x struct {
+		Errors          ValidationErrors `xml:"errors"`
+		ErrorMessage    string           `xml:"message"`
+		MerchantAccount *MerchantAccount `xml:"merchant-account"`
+		Transaction     *Transaction     `xml:"transaction"`
+	}
+	err := d.DecodeElement(&x, &start)
+	if err != nil {
+		return err
+	}
+	e.errors = x.Errors
+	e.ErrorMessage = x.ErrorMessage
+	e.MerchantAccount = x.MerchantAccount
+	e.Transaction = x.Transaction
+	return nil
 }
 
 func (e *BraintreeError) Error() string {
@@ -24,90 +43,164 @@ func (e *BraintreeError) StatusCode() int {
 	return e.statusCode
 }
 
-func (e *BraintreeError) All() []FieldError {
-	baseErrors := e.Errors.TransactionErrors.ErrorList.Errors
-	creditCardErrors := e.Errors.TransactionErrors.CreditCardErrors.ErrorList.Errors
-	customerErrors := e.Errors.TransactionErrors.CustomerErrors.ErrorList.Errors
-	allErrors := append(baseErrors, creditCardErrors...)
-	allErrors = append(allErrors, customerErrors...)
-	return allErrors
+func (e *BraintreeError) All() []ValidationError {
+	return e.errors.AllDeep()
 }
 
-func (e *BraintreeError) For(item string) errorGroup {
-	switch item {
-	default:
-		return nil
-	case "Transaction":
-		return e.Errors.TransactionErrors
+func (e *BraintreeError) For(name string) *ValidationErrors {
+	return e.errors.For(name)
+}
+
+type ValidationErrors struct {
+	Object           string
+	ValidationErrors []ValidationError
+	Children         map[string]*ValidationErrors
+}
+
+func (r *ValidationErrors) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	for {
+		t, err := d.Token()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		r.Object = errorNameKebabToCamel(start.Name.Local)
+
+		if subStart, ok := t.(xml.StartElement); ok {
+			subName := subStart.Name.Local
+			if subName == "errors" {
+				errorList := struct {
+					ErrorList []ValidationError `xml:"error"`
+				}{}
+				err := d.DecodeElement(&errorList, &subStart)
+				if err != nil {
+					return err
+				}
+				r.ValidationErrors = errorList.ErrorList
+			} else {
+				subSectionName := errorNameKebabToCamel(subName)
+				subSection := &ValidationErrors{}
+				err := d.DecodeElement(subSection, &subStart)
+				if err != nil {
+					return err
+				}
+				if r.Children == nil {
+					r.Children = map[string]*ValidationErrors{}
+				}
+				r.Children[subSectionName] = subSection
+			}
+		}
 	}
-}
-
-func (e *BraintreeError) On(item string) []FieldError {
-	return []FieldError{}
-}
-
-type responseErrors struct {
-	TransactionErrors responseError `xml:"transaction"`
-}
-
-type responseError struct {
-	ErrorList        errorList  `xml:"errors"`
-	CreditCardErrors errorBlock `xml:"credit-card"`
-	CustomerErrors   errorBlock `xml:"customer"`
-}
-
-func (r responseError) For(item string) errorGroup {
-	switch item {
-	default:
-		return nil
-	case "Base":
-		return r.ErrorList.Errors
-	case "Customer":
-		return r.CustomerErrors.ErrorList.Errors
-	case "CreditCard":
-		return r.CreditCardErrors.ErrorList.Errors
-	}
-}
-
-func (r responseError) On(item string) []FieldError {
-	switch item {
-	default:
-		return []FieldError{}
-	case "Base":
-		return r.ErrorList.Errors
-	case "Customer":
-		return r.CustomerErrors.ErrorList.Errors
-	case "CreditCard":
-		return r.CreditCardErrors.ErrorList.Errors
-	}
-}
-
-type errorBlock struct {
-	ErrorList errorList `xml:"errors"`
-}
-
-type errorList struct {
-	Errors FieldErrorList `xml:"error"`
-}
-
-type FieldErrorList []FieldError
-
-func (f FieldErrorList) For(item string) errorGroup {
 	return nil
 }
 
-func (f FieldErrorList) On(item string) []FieldError {
-	errors := make([]FieldError, 0)
-	for _, e := range f {
-		if strings.ToLower(item) == e.Attribute {
+func (r *ValidationErrors) All() []ValidationError {
+	if r == nil {
+		return nil
+	}
+	return r.ValidationErrors
+}
+
+func (r *ValidationErrors) AllDeep() []ValidationError {
+	if r == nil {
+		return nil
+	}
+	errorList := append([]ValidationError{}, r.All()...)
+	for _, sub := range r.Children {
+		errorList = append(errorList, sub.AllDeep()...)
+	}
+	return errorList
+}
+
+func (r *ValidationErrors) For(name string) *ValidationErrors {
+	if r == nil || r.Children == nil {
+		return (*ValidationErrors)(nil)
+	}
+	return r.Children[name]
+}
+
+func (r *ValidationErrors) ForIndex(i int) *ValidationErrors {
+	if r == nil || r.Children == nil {
+		return (*ValidationErrors)(nil)
+	}
+	return r.Children["Index"+strconv.Itoa(i)]
+}
+
+func (r *ValidationErrors) On(name string) []ValidationError {
+	if r == nil {
+		return nil
+	}
+	errors := make([]ValidationError, 0)
+	for _, e := range r.ValidationErrors {
+		if name == e.Attribute {
 			errors = append(errors, e)
 		}
 	}
 	return errors
 }
 
-type FieldError struct {
-	Code      string `xml:"code"`
-	Attribute string `xml:"attribute"`
-	Message   string `xml:"message"`
+type ValidationError struct {
+	Code      string
+	Attribute string
+	Message   string
+}
+
+func (e *ValidationError) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var x struct {
+		Code      string `xml:"code"`
+		Attribute string `xml:"attribute"`
+		Message   string `xml:"message"`
+	}
+	err := d.DecodeElement(&x, &start)
+	if err != nil {
+		return err
+	}
+	e.Code = x.Code
+	e.Attribute = errorNameSnakeToCamel(x.Attribute)
+	e.Message = x.Message
+	return nil
+}
+
+func errorNameSnakeToCamel(snake string) string {
+	if len(snake) == 0 {
+		return ""
+	}
+	camel := bytes.Buffer{}
+	capitalizeNext := true
+	for i := 0; i < len(snake); i++ {
+		s := snake[i]
+		if s == '_' {
+			capitalizeNext = true
+			continue
+		} else if capitalizeNext {
+			camel.WriteByte(byte(unicode.ToUpper(rune(s))))
+		} else {
+			camel.WriteByte(s)
+		}
+		capitalizeNext = false
+	}
+	return camel.String()
+}
+
+func errorNameKebabToCamel(kebab string) string {
+	if len(kebab) == 0 {
+		return ""
+	}
+	camel := bytes.Buffer{}
+	capitalizeNext := true
+	for i := 0; i < len(kebab); i++ {
+		k := kebab[i]
+		if k == '-' {
+			capitalizeNext = true
+			continue
+		} else if capitalizeNext {
+			camel.WriteByte(byte(unicode.ToUpper(rune(k))))
+		} else {
+			camel.WriteByte(k)
+		}
+		capitalizeNext = false
+	}
+	return camel.String()
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -14,6 +14,11 @@ var errorXML = []byte(`<?xml version="1.0" encoding="UTF-8"?>
     <transaction>
       <errors type="array">
         <error>
+          <code>91560</code>
+          <attribute type="symbol">base</attribute>
+          <message>Transaction could not be held in escrow.</message>
+        </error>
+        <error>
           <code>81502</code>
           <attribute type="symbol">amount</attribute>
           <message>Amount is required.</message>
@@ -27,6 +32,11 @@ var errorXML = []byte(`<?xml version="1.0" encoding="UTF-8"?>
           <code>91513</code>
           <attribute type="symbol">merchant_account_id</attribute>
           <message>Merchant account ID is invalid.</message>
+        </error>
+        <error>
+          <code>915157</code>
+          <attribute type="symbol">line_items</attribute>
+          <message>Too many line items.</message>
         </error>
       </errors>
       <credit-card>
@@ -62,6 +72,31 @@ var errorXML = []byte(`<?xml version="1.0" encoding="UTF-8"?>
           </error>
         </errors>
       </customer>
+      <line-items>
+        <index-1>
+          <errors type="array">
+            <error>
+              <code>95801</code>
+              <attribute type="symbol">commodity_code</attribute>
+              <message>Commodity code is too long.</message>
+            </error>
+          </errors>
+        </index-1>
+        <index-3>
+          <errors type="array">
+            <error>
+              <code>95803</code>
+              <attribute type="symbol">description</attribute>
+              <message>Description is too long.</message>
+            </error>
+            <error>
+              <code>95809</code>
+              <attribute type="symbol">product_code</attribute>
+              <message>Product code is too long.</message>
+            </error>
+          </errors>
+        </index-3>
+      </line-items>
     </transaction>
   </errors>
   <message>Everything is broken!</message>
@@ -78,12 +113,12 @@ func TestErrorsUnmarshalEverything(t *testing.T) {
 
 	allErrors := apiErrors.All()
 
-	if len(allErrors) != 8 {
-		t.Fatal("Did not get all errors")
+	if g, w := len(allErrors), 13; g != w {
+		t.Fatalf("got %d errors, want %d errors", g, w)
 	}
 }
 
-func TestAccessors(t *testing.T) {
+func TestErrorsAccessors(t *testing.T) {
 	t.Parallel()
 
 	apiErrors := &BraintreeError{}
@@ -92,23 +127,106 @@ func TestAccessors(t *testing.T) {
 		t.Fatal("Error unmarshalling: " + err.Error())
 	}
 
-	ccErrors := apiErrors.For("Transaction").On("CreditCard")
+	ccObjectErrors := apiErrors.For("Transaction").For("CreditCard")
+	if g, w := ccObjectErrors.Object, "CreditCard"; g != w {
+		t.Errorf("cc object, got %q, want %q", g, w)
+	}
+
+	ccErrors := apiErrors.For("Transaction").For("CreditCard").All()
 	if len(ccErrors) != 4 {
-		t.Fatal("Did not get the right credit card errors")
+		t.Error("Did not get the right credit card errors")
 	}
 
 	numberErrors := apiErrors.For("Transaction").For("CreditCard").On("Number")
 	if len(numberErrors) != 2 {
-		t.Fatal("Did not get the right number errors")
+		t.Error("Did not get the right number errors")
 	}
 
-	customerErrors := apiErrors.For("Transaction").On("Customer")
+	customerErrors := apiErrors.For("Transaction").For("Customer").All()
 	if len(customerErrors) != 1 {
-		t.Fatal("Did not get the right customer errors")
+		t.Error("Did not get the right customer errors")
 	}
 
-	baseErrors := apiErrors.For("Transaction").On("Base")
-	if len(baseErrors) != 3 {
-		t.Fatal("Did not get the right base errors")
+	lineItemsErrors := apiErrors.For("Transaction").On("LineItems")
+	if g, w := len(lineItemsErrors), 1; g != w {
+		t.Errorf("line items, got %d, want %d", g, w)
+	}
+
+	lineItem1CommodityCodeErrors := apiErrors.For("Transaction").For("LineItems").ForIndex(1).On("CommodityCode")
+	if g, w := len(lineItem1CommodityCodeErrors), 1; g != w {
+		t.Errorf("line item 1, got %d, want %d", g, w)
+	}
+	if g, w := lineItem1CommodityCodeErrors[0].Code, "95801"; g != w {
+		t.Errorf("line item 1, got %q, want %q", g, w)
+	}
+	if g, w := lineItem1CommodityCodeErrors[0].Attribute, "CommodityCode"; g != w {
+		t.Errorf("line item 1, got %q, want %q", g, w)
+	}
+	if g, w := lineItem1CommodityCodeErrors[0].Message, "Commodity code is too long."; g != w {
+		t.Errorf("line item 1, got %q, want %q", g, w)
+	}
+
+	lineItem3Errors := apiErrors.For("Transaction").For("LineItems").ForIndex(3).On("Description")
+	if g, w := len(lineItem3Errors), 1; g != w {
+		t.Errorf("line item 3, got %d, want %d", g, w)
+	}
+
+	baseErrors := apiErrors.For("Transaction").All()
+	if g, w := len(baseErrors), 5; g != w {
+		t.Errorf("transaction, got %d, want %d", g, w)
+	}
+
+	baseBaseErrors := apiErrors.For("Transaction").On("Base")
+	if g, w := len(baseBaseErrors), 1; g != w {
+		t.Errorf("transaction base, got %d, want %d", g, w)
+	}
+}
+
+func TestErrorsNameSnakeToCamel(t *testing.T) {
+	cases := []struct {
+		Snake string
+		Camel string
+	}{
+		{"amount", "Amount"},
+		{"index_1", "Index1"},
+		{"index_123", "Index123"},
+		{"commodity_code", "CommodityCode"},
+		{"description", "Description"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Snake+"=>"+c.Camel, func(t *testing.T) {
+			camel := errorNameSnakeToCamel(c.Snake)
+			if g, w := camel, c.Camel; g == w {
+				t.Logf("got %q, want %q", g, w)
+			} else {
+				t.Errorf("got %q, want %q", g, w)
+			}
+		})
+	}
+}
+
+func TestErrorsNameKebabToCamel(t *testing.T) {
+	cases := []struct {
+		Kebab string
+		Camel string
+	}{
+		{"amount", "Amount"},
+		{"line-items", "LineItems"},
+		{"index-1", "Index1"},
+		{"index-123", "Index123"},
+		{"commodity-code", "CommodityCode"},
+		{"description", "Description"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Kebab+"=>"+c.Camel, func(t *testing.T) {
+			camel := errorNameKebabToCamel(c.Kebab)
+			if g, w := camel, c.Camel; g == w {
+				t.Logf("got %q, want %q", g, w)
+			} else {
+				t.Errorf("got %q, want %q", g, w)
+			}
+		})
 	}
 }

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -1263,7 +1263,7 @@ func TestEscrowHoldOnCreateOnMasterMerchant(t *testing.T) {
 	if err == nil {
 		t.Fatal("Transaction Sale got no error, want error")
 	}
-	errors := err.(*BraintreeError).Errors.TransactionErrors.For("Base").On("base")
+	errors := err.(*BraintreeError).For("Transaction").On("Base")
 	if len(errors) != 1 {
 		t.Fatalf("Transaction Sale got %d errors, want 1 error", len(errors))
 	}
@@ -1322,7 +1322,7 @@ func TestEscrowHoldAfterSaleOnMasterMerchant(t *testing.T) {
 	if err == nil {
 		t.Fatal("Transaction HoldInEscrow got no error, want error")
 	}
-	errors := err.(*BraintreeError).Errors.TransactionErrors.For("Base").On("base")
+	errors := err.(*BraintreeError).For("Transaction").On("Base")
 	if len(errors) != 1 {
 		t.Fatalf("Transaction HoldInEscrow got %d errors, want 1 error", len(errors))
 	}
@@ -1391,7 +1391,7 @@ func TestEscrowReleaseNotEscrowed(t *testing.T) {
 	if err == nil {
 		t.Fatal("Transaction ReleaseFromEscrow got no error, want error")
 	}
-	errors := err.(*BraintreeError).Errors.TransactionErrors.For("Base").On("base")
+	errors := err.(*BraintreeError).For("Transaction").On("Base")
 	if len(errors) != 1 {
 		t.Fatalf("Transaction ReleaseFromEscrow got %d errors, want 1 error", len(errors))
 	}
@@ -1467,7 +1467,7 @@ func TestEscrowCancelReleaseNotPending(t *testing.T) {
 	if err == nil {
 		t.Fatal("Transaction Cancel Release got no error, want error")
 	}
-	errors := err.(*BraintreeError).Errors.TransactionErrors.For("Base").On("base")
+	errors := err.(*BraintreeError).For("Transaction").On("Base")
 	if len(errors) != 1 {
 		t.Fatalf("Transaction Cancel Release got %d errors, want 1 error", len(errors))
 	}

--- a/webhook_notification.go
+++ b/webhook_notification.go
@@ -56,7 +56,7 @@ func (n *WebhookNotification) Disbursement() *Disbursement {
 
 type webhookSubject struct {
 	XMLName          xml.Name         `xml:"subject"`
-	APIErrorResponse *BraintreeError  `xml:",omitempty"`
+	APIErrorResponse *BraintreeError  `xml:"api-error-response,omitempty"`
 	Disbursement     *Disbursement    `xml:"disbursement,omitempty"`
 	Subscription     *Subscription    `xml:",omitempty"`
 	MerchantAccount  *MerchantAccount `xml:"merchant-account,omitempty"`


### PR DESCRIPTION
Rewrite the parsing of validation errors, so that all objects and fields returned in an error response are available. Motivation for doing this is because #214 adds line items but the existing error code can't support dynamic error responses that contains errors for parameter arrays.

In the process of rewriting this I found several bugs with how validation errors were parsed, and they're fixed by this change. Examples:
1. You no longer need to call `.For("Transaction").For("Base").For("Base")` to get to the base errors on a Transaction, instead you call `.For("Transaction").For("Base")`.
2. There is no longer an inconsistency between the casing of object names and attributes, as all are normalized to their matching struct fields, which is title camel case. e.g. `CreditCard`, `DiscountAmount`.

Since so much was changing, I also normalized some of the names of structs with the names used in the official Braintree SDKs, so it's easier to understand how to use the this SDK by reading the standard Braintree developer docs. e.g. `FieldError` => `ValidationError`.

Because of the numerous changes this change is a breaking change, but only for consumers who were using the `For` and `On` functions to find specific errors.