### PR TITLE
Fix errcheck fmt.Fprintf analysis failure

### DIFF
--- a/examples/transaction/server.go
+++ b/examples/transaction/server.go
@@ -63,9 +63,9 @@ func createTransaction(w http.ResponseWriter, r *http.Request) {
 	_, err := bt.Transaction().Create(ctx, tx)
 
 	if err == nil {
-		fmt.Fprintf(w, "<h1>Success!</h1>")
+		_, _ = fmt.Fprintf(w, "<h1>Success!</h1>")
 	} else {
-		fmt.Fprintf(w, "<h1>Something went wrong: "+err.Error()+"</h1>")
+		_, _ = fmt.Fprintf(w, "<h1>Something went wrong: "+err.Error()+"</h1>")
 	}
 }
 


### PR DESCRIPTION
What
===
Explicitly indicate that we don't care about the error returned by
`fmt.Fprintf` in the example code.

Why
===
Errcheck started considering `fmt.Fprintf` as a function that returns an
error that should be checked. We wouldn't do anything if an error was
returned by the function in the example so setting the error to `_` will
have errcheck ignore it.