### PR TITLE
Add Current billing cycle field to Discount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ IMPROVEMENTS:
 
 * Add TransactionLineItemGateway, TransactionLineItem, TransactionLineItemRequest.
 * Add LineItems to TransactionRequest.
+* Add CurrentBillingCycle to Modification.
 
 ## 0.18.0 (March 2nd, 2018)
 

--- a/discount_integration_test.go
+++ b/discount_integration_test.go
@@ -33,7 +33,7 @@ func TestDiscounts(t *testing.T) {
 	} else if discount.Name != "test_discount_name" {
 		t.Fatalf("expected Name to be %s, was %s", "test_discount_name", discount.Name)
 	} else if discount.NeverExpires != true {
-		t.Fatalf("expected NeverExpires to be %v, was %v", true, discount.NeverExpires)
+		t.Fatalf("expected NeverExpires to be %t, was %t", true, discount.NeverExpires)
 	} else if discount.Description != "A test discount" {
 		t.Fatalf("expected Description to be %s, was %s", "A test discount", discount.Description)
 	}

--- a/discount_integration_test.go
+++ b/discount_integration_test.go
@@ -34,6 +34,8 @@ func TestDiscounts(t *testing.T) {
 		t.Fatalf("expected Name to be %s, was %s", "test_discount_name", discount.Name)
 	} else if discount.NeverExpires != true {
 		t.Fatalf("expected NeverExpires to be %t, was %t", true, discount.NeverExpires)
+	} else if discount.CurrentBillingCycle != 0 {
+		t.Fatalf("expected current billing cycle to be %d, was %d", 0, discount.CurrentBillingCycle)
 	} else if discount.Description != "A test discount" {
 		t.Fatalf("expected Description to be %s, was %s", "A test discount", discount.Description)
 	}

--- a/modification.go
+++ b/modification.go
@@ -16,5 +16,6 @@ type Modification struct {
 	NeverExpires          bool       `xml:"never-expires"`
 	Quantity              int        `xml:"quantity"`
 	NumberOfBillingCycles int        `xml:"number-of-billing-cycles"`
+	CurrentBillingCycle   int        `xml:"current-billing-cycle"`
 	UpdatedAt             *time.Time `xml:"updated_at"`
 }

--- a/subscription_integration_test.go
+++ b/subscription_integration_test.go
@@ -925,6 +925,9 @@ func TestSubscriptionModifications(t *testing.T) {
 	if x := sub2.Discounts.Discounts[0].NumberOfBillingCycles; x != 2 {
 		t.Fatalf("got %v number of billing cycles on discount, want 2 billing cycles", x)
 	}
+	if x := sub2.Discounts.Discounts[0].CurrentBillingCycle; x != 0 {
+		t.Fatalf("got current billing cycle of %d on discount, want 0", x)
+	}
 
 	// Update AddOn
 	sub3, err := g.Update(ctx, &SubscriptionRequest{


### PR DESCRIPTION
(The first commit is just a drive-by cleanup)

This field is useful if you want to determine if a Discount is still ongoing or not.

With the plans in the default environment this is difficult to test (because they only apply the discount after a trial/at the end of the month) but I verified that the field is being picked up on our installation.