### PR TITLE
Add SearchPage to TransactionGateway and SubscriptionGateway

### DIFF
--- a/search.go
+++ b/search.go
@@ -21,8 +21,9 @@ func (s *SearchQuery) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 }
 
 type SearchResult struct {
-	PageSize int
-	IDs      []string
+	PageSize  int
+	PageCount int
+	IDs       []string
 }
 
 type TextField struct {

--- a/transaction_gateway.go
+++ b/transaction_gateway.go
@@ -153,8 +153,8 @@ func (g *TransactionGateway) Find(ctx context.Context, id string) (*Transaction,
 	return nil, &invalidResponseError{resp}
 }
 
-// SearchIDs finds transactions matching the search query, returning the IDs
-// only. Use Search and SearchNext to get pages of transactions.
+// SearchIDs finds transactions matching the search query, returning the IDs only.
+// Use SearchPage to get pages of transactions.
 func (g *TransactionGateway) SearchIDs(ctx context.Context, query *SearchQuery) (*SearchResult, error) {
 	resp, err := g.execute(ctx, "POST", "transactions/advanced_search_ids", query)
 	if err != nil {
@@ -173,13 +173,45 @@ func (g *TransactionGateway) SearchIDs(ctx context.Context, query *SearchQuery) 
 	}
 
 	return &SearchResult{
-		PageSize: searchResult.PageSize,
-		IDs:      searchResult.Ids.Item,
+		PageSize:  searchResult.PageSize,
+		PageCount: (len(searchResult.Ids.Item) + searchResult.PageSize - 1) / searchResult.PageSize,
+		IDs:       searchResult.Ids.Item,
 	}, nil
+}
+
+// SearchPage gets the page of transactions matching the search query.
+// Use Search to start a search and use it's result object to get pages.
+// Page numbers start at 1.
+// Returns a nil result and nil error when no more results are available.
+func (g *TransactionGateway) SearchPage(ctx context.Context, query *SearchQuery, searchResult *SearchResult, page int) (*TransactionSearchResult, error) {
+	startOffset := (page - 0) * searchResult.PageSize
+	endOffset := startOffset + searchResult.PageSize
+	if endOffset > len(searchResult.IDs) {
+		endOffset = len(searchResult.IDs)
+	}
+	if startOffset >= endOffset {
+		return nil, nil
+	}
+
+	pageQuery := query.shallowCopy()
+	pageQuery.AddMultiField("ids").Items = searchResult.IDs[startOffset:endOffset]
+	transactions, err := g.fetchTransactions(ctx, pageQuery)
+
+	pageResult := &TransactionSearchResult{
+		TotalItems:        len(searchResult.IDs),
+		TotalIDs:          searchResult.IDs,
+		CurrentPageNumber: page,
+		PageSize:          searchResult.PageSize,
+		Transactions:      transactions,
+	}
+
+	return pageResult, err
 }
 
 // Search finds transactions matching the search query, returning the first
 // page of results. Use SearchNext to get subsequent pages.
+//
+// Deprecated: Use SearchIDs and SearchPage.
 func (g *TransactionGateway) Search(ctx context.Context, query *SearchQuery) (*TransactionSearchResult, error) {
 	searchResult, err := g.SearchIDs(ctx, query)
 	if err != nil {
@@ -212,6 +244,8 @@ func (g *TransactionGateway) Search(ctx context.Context, query *SearchQuery) (*T
 // SearchNext finds the next page of transactions matching the search query.
 // Use Search to start a search and get the first page of results.
 // Returns a nil result and nil error when no more results are available.
+//
+// Deprecated: Use SearchIDs and SearchPage.
 func (g *TransactionGateway) SearchNext(ctx context.Context, query *SearchQuery, prevResult *TransactionSearchResult) (*TransactionSearchResult, error) {
 	startOffset := prevResult.CurrentPageNumber * prevResult.PageSize
 	endOffset := startOffset + prevResult.PageSize

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -125,6 +125,78 @@ func TestTransactionSearchIDs(t *testing.T) {
 	}
 }
 
+func TestTransactionSearchPage(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	txg := testGateway.Transaction()
+
+	const transactionCount = 51
+	transactionIDs := map[string]bool{}
+	prefix := "PaginationTest-" + testhelpers.RandomString()
+	for i := 0; i < transactionCount; i++ {
+		unique := testhelpers.RandomString()
+		tx, err := txg.Create(ctx, &TransactionRequest{
+			Type:   "sale",
+			Amount: randomAmount(),
+			Customer: &CustomerRequest{
+				FirstName: prefix + unique,
+			},
+			CreditCard: &CreditCard{
+				Number:         testCreditCards["visa"].Number,
+				ExpirationDate: "05/14",
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		transactionIDs[tx.Id] = true
+	}
+
+	t.Logf("transactionIDs = %v", transactionIDs)
+
+	query := new(SearchQuery)
+	query.AddTextField("customer-first-name").StartsWith = prefix
+
+	results, err := txg.SearchIDs(ctx, query)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("results.PageSize = %v", results.PageSize)
+	t.Logf("results.PageCount = %v", results.PageCount)
+	t.Logf("results.IDs = %d %v", len(results.IDs), results.IDs)
+
+	if len(results.IDs) != transactionCount {
+		t.Fatalf("results.IDs = %v, want %v", len(results.IDs), transactionCount)
+	}
+
+	for page := 0; page <= results.PageCount; page++ {
+		results, err := txg.SearchPage(ctx, query, results, page)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if results == nil {
+			break
+		}
+		for _, tx := range results.Transactions {
+			if firstName := tx.Customer.FirstName; !strings.HasPrefix(firstName, prefix) {
+				t.Fatalf("tx.Customer.FirstName = %q, want prefix of %q", firstName, prefix)
+			}
+			if transactionIDs[tx.Id] {
+				delete(transactionIDs, tx.Id)
+			} else {
+				t.Fatalf("tx.Id = %q, not expected", tx.Id)
+			}
+		}
+	}
+
+	if len(transactionIDs) > 0 {
+		t.Fatalf("transactions not returned = %v", transactionIDs)
+	}
+}
+
 func TestTransactionSearch(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
What
===
Add `SearchPage` to `TransactionGatewag` and `SubscriptionGateway` that
can be used to page through search results returned by `SearchIDs`.
Deprecate other search functions, `Search` and `SearchNext`.

Why
===
The existing pagination pattern of using the `Search` and `SearchNext`
functions are not simple to program with, and they limit access to the
search space and assume the developer will want to search sequentially
through the pages.

The complexity with using the functions primarily comes from the fact
that the developer gets paged results from two different functions. This
means the developer cannot put those functions merely in a for loop and
iterate. They must call one first, deal with those results, then loop on
the second function. It is less intuitive to write code this way, and
much easier to think about if we get the IDs first, then just iterate
over them in pages.