### PR TITLE
Adding StoreInVaultOnSuccess in TransactionOptions

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -177,6 +177,7 @@ type Transactions struct {
 type TransactionOptions struct {
 	SubmitForSettlement              bool                             `xml:"submit-for-settlement,omitempty"`
 	StoreInVault                     bool                             `xml:"store-in-vault,omitempty"`
+	StoreInVaultOnSuccess            bool                             `xml:"store-in-vault-on-success,omitempty"`
 	AddBillingAddressToPaymentMethod bool                             `xml:"add-billing-address-to-payment-method,omitempty"`
 	StoreShippingAddressInVault      bool                             `xml:"store-shipping-address-in-vault,omitempty"`
 	HoldInEscrow                     bool                             `xml:"hold-in-escrow,omitempty"`


### PR DESCRIPTION
Thank you @lionelbarrow for all your work on this excellent client library for Braintree API. In this PR I am adding an additional option for controlling when the tokens are stored in Braintree's Vault:

- [x] Adding `StoreInVaultOnSuccess` field for `TransactionOptions`. From the [docs](https://developers.braintreepayments.com/reference/request/transaction/sale/php#options.store_in_vault_on_success):
> The option that determines whether the payment method associated with the successful transaction should be stored in the Vault.

- [x] Adding also tests for `StoreInVault`.
