### PR TITLE
Correct test documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ For details on this package, see [GoDoc](http://godoc.org/github.com/lionelbarro
 The integration tests run against a sandbox account created in the [Braintree Sandbox](https://sandbox.braintreegateway.com/).
 See [TESTING.md](TESTING.md) for further instructions on how to set up your sandbox for integration testing.
 
-You can run tests locally using the same credentials that Travis CI uses by using the credentials in `.default.env`. Simply `cp .default.env .env` if you use a tool that autoloads `.env` files, or `source .default.env` to load the credentials into your shell. Then run tests with `go test ./...`.
+You can run tests locally using the same credentials that Travis CI uses by using the credentials in `.default.env`. Simply `cp .default.env .env` if you use a tool that autoloads `.env` files, or `source .default.env` to load the credentials into your shell. Then run tests with `go test -tags='unit integration' ./...`.
 
 ```
 source .default.env
-go test ./...
+go test -tags='unit integration' ./...
 ```
 
 ### Webhook Integration Testing


### PR DESCRIPTION
What
===
Update the commands in README.md for running tests to set the
appropriate tags so that all test files tests get executed.

Why
===
Sometime ago tags were added to differentiate between unit and
integration tests, but README.md wasn't updated.

Fixes #235