### PR TITLE
Allow Transaction RiskData ID to be empty if not evaluated

### DIFF
--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -968,6 +968,7 @@ func TestAllTransactionFields(t *testing.T) {
 	if tx2.RiskData == nil {
 		t.Fatal("expected tx2.RiskData not to be empty")
 	}
+	t.Logf("RiskData: %+v", tx2.RiskData)
 	switch tx2.RiskData.Decision {
 	case "Not Evaluated":
 		if tx2.RiskData.ID != "" {

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -968,11 +968,17 @@ func TestAllTransactionFields(t *testing.T) {
 	if tx2.RiskData == nil {
 		t.Fatal("expected tx2.RiskData not to be empty")
 	}
-	if tx2.RiskData.ID == "" {
-		t.Fatal("expected tx2.RiskData.ID not to be empty")
-	}
-	if tx2.RiskData.Decision != "Approve" {
-		t.Fatalf("expected tx2.RiskData.Decision to be Approve, but got %s", tx2.RiskData.Decision)
+	switch tx2.RiskData.Decision {
+	case "Not Evaluated":
+		if tx2.RiskData.ID != "" {
+			t.Fatalf("expected tx2.RiskData.ID to be empty when Decision is Not Evaluated, but got %q", tx2.RiskData.ID)
+		}
+	case "Approve":
+		if tx2.RiskData.ID == "" {
+			t.Fatalf("expected tx2.RiskData.ID to be non-empty when Decision is Approved, but got %q", tx2.RiskData.ID)
+		}
+	default:
+		t.Fatalf("expected tx2.RiskData.Decision to be Not Evaluated or Approved, but got %s", tx2.RiskData.Decision)
 	}
 	if tx2.Channel != "ChannelA" {
 		t.Fatalf("expected tx2.Channel to be ChannelA, but got %s", tx2.Channel)


### PR DESCRIPTION
What
===
Change test expectation to allow `Transaction` `RiskData` `ID` to be
empty when the `RiskData` `Decision` is `Not Evaluated`.

Why
===
From time to time we get back an empty ID. I think this is because
sometimes we're getting back a `Not Evaluated` decision and the ID isn't
being set. According to the Braintree documentation `Not Evaluated` can
be returned sometimes irrespective of how we setup the transaction.
https://articles.braintreepayments.com/guides/fraud-tools/advanced/kount-standard#not-evaluated-transactions