### PR TITLE
Run tests with go1.11beta3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
       script: make test
 
     - stage: test
-      go: "1.11beta2"
+      go: "1.11beta3"
       script: make test
 
     - stage: test


### PR DESCRIPTION
What
===
Run tests with go1.11beta3, removing go1.11beta2.

Why
===
We should run tests with the latest beta to ensure the package is
prepared for the next release. Go1.11beta3 was just released.