### PR TITLE
adds account updater daily report to possible webhook subjects

### DIFF
--- a/account_updater_daily_report.go
+++ b/account_updater_daily_report.go
@@ -1,0 +1,9 @@
+package braintree
+
+import "encoding/xml"
+
+type AccountUpdaterDailyReport struct {
+	XMLName    xml.Name `xml:"account-updater-daily-report"`
+	ReportDate string   `xml:"report-date"`
+	ReportURL  string   `xml:"report-url"`
+}

--- a/webhook_notification.go
+++ b/webhook_notification.go
@@ -63,13 +63,14 @@ func (n *WebhookNotification) Dispute() *Dispute {
 }
 
 type webhookSubject struct {
-	XMLName          xml.Name         `xml:"subject"`
-	APIErrorResponse *BraintreeError  `xml:"api-error-response,omitempty"`
-	Disbursement     *Disbursement    `xml:"disbursement,omitempty"`
-	Subscription     *Subscription    `xml:",omitempty"`
-	MerchantAccount  *MerchantAccount `xml:"merchant-account,omitempty"`
-	Transaction      *Transaction     `xml:",omitempty"`
-	Dispute          *Dispute         `xml:"dispute,omitempty"`
+	XMLName                   xml.Name                   `xml:"subject"`
+	APIErrorResponse          *BraintreeError            `xml:"api-error-response,omitempty"`
+	Disbursement              *Disbursement              `xml:"disbursement,omitempty"`
+	Subscription              *Subscription              `xml:",omitempty"`
+	MerchantAccount           *MerchantAccount           `xml:"merchant-account,omitempty"`
+	Transaction               *Transaction               `xml:",omitempty"`
+	Dispute                   *Dispute                   `xml:"dispute,omitempty"`
+	AccountUpdaterDailyReport *AccountUpdaterDailyReport `xml:"account-updater-daily-report,omitempty"`
 
 	// Remaining Fields:
 	// partner_merchant

--- a/webhook_notification.go
+++ b/webhook_notification.go
@@ -62,6 +62,14 @@ func (n *WebhookNotification) Dispute() *Dispute {
 	}
 }
 
+func (n *WebhookNotification) AccountUpdaterDailyReport() *AccountUpdaterDailyReport {
+	if n.Subject.AccountUpdaterDailyReport != nil {
+		return n.Subject.AccountUpdaterDailyReport
+	} else {
+		return nil
+	}
+}
+
 type webhookSubject struct {
 	XMLName                   xml.Name                   `xml:"subject"`
 	APIErrorResponse          *BraintreeError            `xml:"api-error-response,omitempty"`

--- a/webhook_notification_test.go
+++ b/webhook_notification_test.go
@@ -378,9 +378,9 @@ func TestWebhookParseAccountUpdaterDailyReport(t *testing.T) {
 		t.Fatal("Incorrect Notification kind, expected account_updater_daily_report got", notification.Kind)
 	} else if notification.AccountUpdaterDailyReport() == nil {
 		t.Fatal("Notification should have a account updater daily report")
-	} else if len(notification.AccountUpdaterDailyReport().ReportDate) != "2016-01-14" {
+	} else if notification.AccountUpdaterDailyReport().ReportDate != "2016-01-14" {
 		t.Errorf("Incorrect report date, expected 2016-01-14, got %s", notification.AccountUpdaterDailyReport().ReportDate)
-	} else if len(notification.AccountUpdaterDailyReport().ReportURL) != "2016-01-14" {
+	} else if notification.AccountUpdaterDailyReport().ReportURL != "link-to-csv-report" {
 		t.Errorf("Incorrect report date, expected link-to-csv-report, got %s", notification.AccountUpdaterDailyReport().ReportURL)
 	}
 }

--- a/webhook_notification_test.go
+++ b/webhook_notification_test.go
@@ -381,6 +381,6 @@ func TestWebhookParseAccountUpdaterDailyReport(t *testing.T) {
 	} else if notification.AccountUpdaterDailyReport().ReportDate != "2016-01-14" {
 		t.Errorf("Incorrect report date, expected 2016-01-14, got %s", notification.AccountUpdaterDailyReport().ReportDate)
 	} else if notification.AccountUpdaterDailyReport().ReportURL != "link-to-csv-report" {
-		t.Errorf("Incorrect report date, expected link-to-csv-report, got %s", notification.AccountUpdaterDailyReport().ReportURL)
+		t.Errorf("Incorrect report url, expected link-to-csv-report, got %s", notification.AccountUpdaterDailyReport().ReportURL)
 	}
 }


### PR DESCRIPTION
This pull request will make the fields sent by the `AccountUpdaterDailyReportWebhook` Webhook available to the `WebhookNotification` struct. 