### PR TITLE
Adding bin field in ApplePayCard

### DIFF
--- a/apple_pay_card.go
+++ b/apple_pay_card.go
@@ -12,6 +12,7 @@ type ApplePayCard struct {
 	CardType              string         `xml:"card-type"`
 	PaymentInstrumentName string         `xml:"payment-instrument-name"`
 	SourceDescription     string         `xml:"source-description"`
+	Bin                   string         `xml:"bin,omitempty"`
 	Last4                 string         `xml:"last-4"`
 	ExpirationMonth       string         `xml:"expiration-month"`
 	ExpirationYear        string         `xml:"expiration-year"`


### PR DESCRIPTION
Added `bin` (first 6 digits of the credit card number) field in `ApplePayCard` as it is in `CreditCard` and [documented](https://developers.braintreepayments.com/reference/response/apple-pay-card/ruby#bin) in Braintree.
