### PR TITLE
Added BillingAddress field to PaymentMethodRequest

### DIFF
--- a/address.go
+++ b/address.go
@@ -26,19 +26,19 @@ type Address struct {
 }
 
 type AddressRequest struct {
-	XMLName            xml.Name `xml:"address"`
-	FirstName          string   `xml:"first-name,omitempty"`
-	LastName           string   `xml:"last-name,omitempty"`
-	Company            string   `xml:"company,omitempty"`
-	StreetAddress      string   `xml:"street-address,omitempty"`
-	ExtendedAddress    string   `xml:"extended-address,omitempty"`
-	Locality           string   `xml:"locality,omitempty"`
-	Region             string   `xml:"region,omitempty"`
-	PostalCode         string   `xml:"postal-code,omitempty"`
-	CountryCodeAlpha2  string   `xml:"country-code-alpha2,omitempty"`
-	CountryCodeAlpha3  string   `xml:"country-code-alpha3,omitempty"`
-	CountryCodeNumeric string   `xml:"country-code-numeric,omitempty"`
-	CountryName        string   `xml:"country-name,omitempty"`
+	XMLName            xml.Name
+	FirstName          string `xml:"first-name,omitempty"`
+	LastName           string `xml:"last-name,omitempty"`
+	Company            string `xml:"company,omitempty"`
+	StreetAddress      string `xml:"street-address,omitempty"`
+	ExtendedAddress    string `xml:"extended-address,omitempty"`
+	Locality           string `xml:"locality,omitempty"`
+	Region             string `xml:"region,omitempty"`
+	PostalCode         string `xml:"postal-code,omitempty"`
+	CountryCodeAlpha2  string `xml:"country-code-alpha2,omitempty"`
+	CountryCodeAlpha3  string `xml:"country-code-alpha3,omitempty"`
+	CountryCodeNumeric string `xml:"country-code-numeric,omitempty"`
+	CountryName        string `xml:"country-name,omitempty"`
 }
 
 type Addresses struct {

--- a/address_gateway.go
+++ b/address_gateway.go
@@ -10,6 +10,7 @@ type AddressGateway struct {
 
 // Create creates a new address for the specified customer id.
 func (g *AddressGateway) Create(ctx context.Context, customerID string, a *AddressRequest) (*Address, error) {
+	a.XMLName.Local = "address"
 	resp, err := g.execute(ctx, "POST", "customers/"+customerID+"/addresses", &a)
 	if err != nil {
 		return nil, err
@@ -36,6 +37,7 @@ func (g *AddressGateway) Delete(ctx context.Context, customerId, addrId string) 
 
 // Update updates an address for the address id and customer id.
 func (g *AddressGateway) Update(ctx context.Context, customerID, addrID string, a *AddressRequest) (*Address, error) {
+	a.XMLName.Local = "address"
 	resp, err := g.execute(ctx, "PUT", "customers/"+customerID+"/addresses/"+addrID, a)
 	if err != nil {
 		return nil, err

--- a/payment_method_gateway.go
+++ b/payment_method_gateway.go
@@ -15,6 +15,7 @@ type PaymentMethodRequest struct {
 	Token              string                       `xml:"token,omitempty"`
 	PaymentMethodNonce string                       `xml:"payment-method-nonce,omitempty"`
 	Options            *PaymentMethodRequestOptions `xml:"options,omitempty"`
+	BillingAddress     *AddressRequest              `xml:"billing-address,omitempty"`
 }
 
 type PaymentMethodRequestOptions struct {

--- a/payment_method_integration_test.go
+++ b/payment_method_integration_test.go
@@ -25,9 +25,24 @@ func TestPaymentMethod(t *testing.T) {
 	g := testGateway.PaymentMethod()
 
 	// Create using credit card
+	addr := &AddressRequest{
+		FirstName:          "Robert",
+		LastName:           "Smith",
+		Company:            "The Cure",
+		StreetAddress:      "39 Acacia Avenue",
+		ExtendedAddress:    "SAV Studios",
+		Locality:           "North End",
+		Region:             "London",
+		PostalCode:         "SW1A 0AA",
+		CountryCodeAlpha2:  "GB",
+		CountryCodeAlpha3:  "GBR",
+		CountryCodeNumeric: "826",
+		CountryName:        "United Kingdom",
+	}
 	paymentMethod, err := g.Create(ctx, &PaymentMethodRequest{
 		CustomerId:         cust.Id,
 		PaymentMethodNonce: FakeNonceTransactableVisa,
+		BillingAddress:     addr,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -38,6 +53,48 @@ func TestPaymentMethod(t *testing.T) {
 	}
 	if paymentMethod.GetToken() == "" {
 		t.Errorf("Got paymentMethod token %#v, want a value", paymentMethod.GetToken())
+	}
+
+	if card, ok := paymentMethod.(*CreditCard); ok {
+		ba := card.BillingAddress
+		if ba.FirstName != addr.FirstName {
+			t.Errorf("Got paymentMethod billing adress first name %#v, want %#v", ba.FirstName, addr.FirstName)
+		}
+		if ba.LastName != addr.LastName {
+			t.Errorf("Got paymentMethod billing adress last name %#v, want %#v", ba.LastName, addr.LastName)
+		}
+		if ba.Company != addr.Company {
+			t.Errorf("Got paymentMethod billing adress company %#v, want %#v", ba.Company, addr.Company)
+		}
+		if ba.StreetAddress != addr.StreetAddress {
+			t.Errorf("Got paymentMethod billing adress street address %#v, want %#v", ba.StreetAddress, addr.StreetAddress)
+		}
+		if ba.ExtendedAddress != addr.ExtendedAddress {
+			t.Errorf("Got paymentMethod billing adress extended address %#v, want %#v", ba.ExtendedAddress, addr.ExtendedAddress)
+		}
+		if ba.Locality != addr.Locality {
+			t.Errorf("Got paymentMethod billing adress locality %#v, want %#v", ba.Locality, addr.Locality)
+		}
+		if ba.Region != addr.Region {
+			t.Errorf("Got paymentMethod billing adress region %#v, want %#v", ba.Region, addr.Region)
+		}
+		if ba.PostalCode != addr.PostalCode {
+			t.Errorf("Got paymentMethod billing adress postal code %#v, want %#v", ba.PostalCode, addr.PostalCode)
+		}
+		if ba.CountryCodeAlpha2 != addr.CountryCodeAlpha2 {
+			t.Errorf("Got paymentMethod billing adress country alpha2 %#v, want %#v", ba.CountryCodeAlpha2, addr.CountryCodeAlpha2)
+		}
+		if ba.CountryCodeAlpha3 != addr.CountryCodeAlpha3 {
+			t.Errorf("Got paymentMethod billing adress country alpha3 %#v, want %#v", ba.CountryCodeAlpha3, addr.CountryCodeAlpha3)
+		}
+		if ba.CountryCodeNumeric != addr.CountryCodeNumeric {
+			t.Errorf("Got paymentMethod billing adress country numeric %#v, want %#v", ba.CountryCodeNumeric, addr.CountryCodeNumeric)
+		}
+		if ba.CountryName != addr.CountryName {
+			t.Errorf("Got paymentMethod billing adress country name %#v, want %#v", ba.CountryName, addr.CountryName)
+		}
+	} else {
+		t.Error("paymentMethod should have been a credit card")
 	}
 
 	// Update using different credit card

--- a/transaction.go
+++ b/transaction.go
@@ -114,8 +114,8 @@ type TransactionRequest struct {
 	PlanId              string                      `xml:"plan-id,omitempty"`
 	CreditCard          *CreditCard                 `xml:"credit-card,omitempty"`
 	Customer            *CustomerRequest            `xml:"customer,omitempty"`
-	BillingAddress      *Address                    `xml:"billing,omitempty"`
-	ShippingAddress     *Address                    `xml:"shipping,omitempty"`
+	BillingAddress      *AddressRequest             `xml:"billing,omitempty"`
+	ShippingAddress     *AddressRequest             `xml:"shipping,omitempty"`
 	TaxAmount           *Decimal                    `xml:"tax-amount,omitempty"`
 	TaxExempt           bool                        `xml:"tax-exempt,omitempty"`
 	DeviceData          string                      `xml:"device-data,omitempty"`

--- a/transaction_integration_test.go
+++ b/transaction_integration_test.go
@@ -517,7 +517,7 @@ func TestTransactionCreatedWhenAVSBankDoesNotSupport(t *testing.T) {
 			ExpirationDate: "05/14",
 			CVV:            "100",
 		},
-		BillingAddress: &Address{
+		BillingAddress: &AddressRequest{
 			StreetAddress: "1 E Main St",
 			Locality:      "Chicago",
 			Region:        "IL",
@@ -562,7 +562,7 @@ func TestTransactionCreatedWhenAVSPostalDoesNotMatch(t *testing.T) {
 			ExpirationDate: "05/14",
 			CVV:            "100",
 		},
-		BillingAddress: &Address{
+		BillingAddress: &AddressRequest{
 			StreetAddress: "1 E Main St",
 			Locality:      "Chicago",
 			Region:        "IL",
@@ -607,7 +607,7 @@ func TestTransactionCreatedWhenAVStreetAddressDoesNotMatch(t *testing.T) {
 			ExpirationDate: "05/14",
 			CVV:            "100",
 		},
-		BillingAddress: &Address{
+		BillingAddress: &AddressRequest{
 			StreetAddress: "201 E Main St", // Should cause AVS street address not verified response.
 			Locality:      "Chicago",
 			Region:        "IL",
@@ -875,13 +875,13 @@ func TestAllTransactionFields(t *testing.T) {
 		Customer: &CustomerRequest{
 			FirstName: "Lionel",
 		},
-		BillingAddress: &Address{
+		BillingAddress: &AddressRequest{
 			StreetAddress: "1 E Main St",
 			Locality:      "Chicago",
 			Region:        "IL",
 			PostalCode:    "60637",
 		},
-		ShippingAddress: &Address{
+		ShippingAddress: &AddressRequest{
 			StreetAddress: "1 E Main St",
 			Locality:      "Chicago",
 			Region:        "IL",


### PR DESCRIPTION
Why
===
The BrainTree api supports providing billing address when creating a payment method.
It is also the only way to set it on a payment method as the api for credit card requires PCI SAQ D compliance.
https://developers.braintreepayments.com/reference/request/payment-method/create/ruby#billing_address