### PR TITLE
Dispute search

### DIFF
--- a/dispute.go
+++ b/dispute.go
@@ -79,8 +79,8 @@ type DisputeTransaction struct {
 }
 type DisputeSearchResult struct {
 	TotalItems        int
-	TotalPages        int
 	CurrentPageNumber int
+	PageCount         int
 	PageSize          int
 	Disputes          []*Dispute
 }

--- a/dispute.go
+++ b/dispute.go
@@ -77,3 +77,10 @@ type DisputeTransaction struct {
 	PaymentInstrumentSubtype string     `xml:"payment-instrument-subtype"`
 	PurchaseOrderNumber      string     `xml:"purchase-order-number"`
 }
+type DisputeSearchResult struct {
+	TotalItems        int
+	TotalPages        int
+	CurrentPageNumber int
+	PageSize          int
+	Disputes          []*Dispute
+}

--- a/dispute_gateway.go
+++ b/dispute_gateway.go
@@ -32,7 +32,7 @@ func (g *DisputeGateway) fetchDisputes(ctx context.Context, query *SearchQuery, 
 		pageCount++
 	}
 	result := &DisputeSearchResult{
-		PageCount:        int(math.Trunc(pageCount)),
+		PageCount:         int(math.Trunc(pageCount)),
 		PageSize:          v.PageSize,
 		TotalItems:        v.TotalItems,
 		CurrentPageNumber: v.CurrentPageNumber,

--- a/dispute_gateway.go
+++ b/dispute_gateway.go
@@ -11,8 +11,8 @@ type DisputeGateway struct {
 	*Braintree
 }
 
-func (g *DisputeGateway) fetchDisputes(ctx context.Context, query *SearchQuery, pageNumber int) (*DisputeSearchResult, error) {
-	resp, err := g.executeVersion(ctx, "POST", fmt.Sprintf("disputes/advanced_search?page=%d", pageNumber), query, apiVersion4)
+func (g *DisputeGateway) fetchDisputes(ctx context.Context, query *SearchQuery, page int) (*DisputeSearchResult, error) {
+	resp, err := g.executeVersion(ctx, "POST", fmt.Sprintf("disputes/advanced_search?page=%d", page), query, apiVersion4)
 	if err != nil {
 		return nil, err
 	}
@@ -45,9 +45,21 @@ func (g *DisputeGateway) Search(ctx context.Context, query *SearchQuery) (*Dispu
 	return g.fetchDisputes(ctx, query, 1)
 }
 
-func (g *DisputeGateway) SearchNext(ctx context.Context, query *SearchQuery, prevResult *DisputeSearchResult) (*DisputeSearchResult, error) {
-	nextPage := prevResult.CurrentPageNumber + 1
-	if nextPage > prevResult.TotalPages {
+func (g *DisputeGateway) SearchPage(ctx context.Context, query *SearchQuery, searchResult *DisputeSearchResult, page int) (*DisputeSearchResult, error) {
+	if searchResult == nil {
+		page = 1
+	} else if page > searchResult.TotalPages {
+		return nil, nil
+	}
+	return g.fetchDisputes(ctx, query, page)
+}
+
+func (g *DisputeGateway) SearchNext(ctx context.Context, query *SearchQuery, searchResult *DisputeSearchResult) (*DisputeSearchResult, error) {
+	if searchResult == nil {
+		return nil, nil
+	}
+	nextPage := searchResult.CurrentPageNumber + 1
+	if nextPage > searchResult.TotalPages {
 		return nil, nil
 	}
 	return g.fetchDisputes(ctx, query, nextPage)

--- a/dispute_gateway.go
+++ b/dispute_gateway.go
@@ -29,7 +29,7 @@ func (g *DisputeGateway) fetchDisputes(ctx context.Context, query *SearchQuery, 
 	}
 	pageCount := float64(v.TotalItems) / float64(v.PageSize)
 	if math.Mod(pageCount, 1) != 0 {
-		pageCount += float64(1)
+		pageCount++
 	}
 	result := &DisputeSearchResult{
 		TotalPages:        int(math.Trunc(pageCount)),

--- a/dispute_gateway.go
+++ b/dispute_gateway.go
@@ -32,7 +32,7 @@ func (g *DisputeGateway) fetchDisputes(ctx context.Context, query *SearchQuery, 
 		pageCount++
 	}
 	result := &DisputeSearchResult{
-		TotalPages:        int(math.Trunc(pageCount)),
+		PageCount:        int(math.Trunc(pageCount)),
 		PageSize:          v.PageSize,
 		TotalItems:        v.TotalItems,
 		CurrentPageNumber: v.CurrentPageNumber,
@@ -48,7 +48,7 @@ func (g *DisputeGateway) Search(ctx context.Context, query *SearchQuery) (*Dispu
 func (g *DisputeGateway) SearchPage(ctx context.Context, query *SearchQuery, searchResult *DisputeSearchResult, page int) (*DisputeSearchResult, error) {
 	if searchResult == nil {
 		page = 1
-	} else if page > searchResult.TotalPages {
+	} else if page > searchResult.PageCount {
 		return nil, nil
 	}
 	return g.fetchDisputes(ctx, query, page)
@@ -59,7 +59,7 @@ func (g *DisputeGateway) SearchNext(ctx context.Context, query *SearchQuery, sea
 		return nil, nil
 	}
 	nextPage := searchResult.CurrentPageNumber + 1
-	if nextPage > searchResult.TotalPages {
+	if nextPage > searchResult.PageCount {
 		return nil, nil
 	}
 	return g.fetchDisputes(ctx, query, nextPage)

--- a/dispute_integration_test.go
+++ b/dispute_integration_test.go
@@ -8,6 +8,146 @@ import (
 	"time"
 )
 
+func TestDisputeSearch(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	tx, err := testGateway.Transaction().Create(ctx, &TransactionRequest{
+		Type:   "sale",
+		Amount: NewDecimal(100, 2),
+		CreditCard: &CreditCard{
+			Number:         "4023898493988028",
+			ExpirationDate: "12/" + time.Now().Format("2006"),
+		},
+		Options: &TransactionOptions{
+			SubmitForSettlement: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create disputed transaction: %v", err)
+	}
+
+	tx, err = testGateway.Transaction().Find(ctx, tx.Id)
+	if err != nil {
+		t.Fatalf("failed to find disputed transaction: %v", err)
+	}
+
+	if len(tx.Disputes) != 1 {
+		t.Fatalf("got Transaction with %d disputes, want 1", len(tx.Disputes))
+	}
+
+	dg := testGateway.Dispute()
+	dispute := tx.Disputes[0]
+
+	if dispute.AmountDisputed.Cmp(NewDecimal(100, 2)) != 0 {
+		t.Errorf("got Dispute AmountDisputed %s, want %s", dispute.AmountDisputed, "1.00")
+	}
+
+	query := new(SearchQuery)
+	f := query.AddTextField("id")
+	f.Is = dispute.ID
+
+	result, err := dg.Search(ctx, query)
+	if err != nil {
+		t.Fatalf("failed to search dispute: %v", err)
+	}
+
+	if len(result.Disputes) != 1 {
+		t.Fatalf("expected 1 dispute, but got %d", len(result.Disputes))
+	}
+
+	if result.Disputes[0].ID != dispute.ID {
+		t.Fatalf("expected transaction with id %s, but got %s", result.Disputes[0].ID, dispute.ID)
+	}
+
+	err = testGateway.Dispute().Finalize(ctx, dispute.ID)
+
+	if err != nil {
+		t.Fatalf("failed to finalize dispute: %v", err)
+	}
+}
+
+func TestDisputeSearchNext(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	txg := testGateway.Transaction()
+	dg := testGateway.Dispute()
+
+	const transactionCount = 51
+	createdDisputeIDs := map[string]bool{}
+	for i := 0; i < transactionCount; i++ {
+		tx, err := txg.Create(ctx, &TransactionRequest{
+			Type: 			"sale",
+			Amount: 		NewDecimal(100, 2),
+			CreditCard: &CreditCard{
+				Number:         "4023898493988028",
+				ExpirationDate: "12/" + time.Now().Format("2006"),
+			},
+			Options: &TransactionOptions{
+				SubmitForSettlement: true,
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		createdDisputeIDs[tx.Disputes[0].ID] = true
+	}
+
+	query := new(SearchQuery)
+	f := query.AddMultiField("kind")
+	f.Items = []string{string(DisputeKindChargeback)}
+	f = query.AddMultiField("status")
+	f.Items = []string{string(DisputeStatusOpen)}
+
+	var index int = 0
+	var matchedDisputeIDs []string
+	var result *DisputeSearchResult
+	var err error
+
+	for {
+		if (index == 0) {
+			result, err = dg.Search(ctx, query)
+		} else {
+			result, err = dg.SearchNext(ctx, query, result)
+		}
+
+		if err != nil {
+			t.Fatalf("failed to search dispute: %v", err)
+		}
+
+		if result == nil && err == nil {
+			break;
+		}
+
+		if result.TotalPages != 2 {
+			t.Fatalf("expected 2 pages of disputes, but got %d", result.TotalPages)
+		}
+
+		if result.TotalItems != transactionCount {
+			t.Fatalf("expected %d disputes, but got %d", transactionCount, result.TotalItems)
+		}
+
+		for _, dispute := range result.Disputes {
+			matchedDisputeIDs = append(matchedDisputeIDs, dispute.ID)
+		}
+		index++
+	}
+
+	for _, disputeID := range matchedDisputeIDs {
+		err = dg.Finalize(ctx, disputeID)
+		if err != nil {
+			t.Fatalf("failed to finalize dispute: %v", err)
+		}
+		delete(createdDisputeIDs, disputeID)
+	}
+
+	if len(createdDisputeIDs) > 0 {
+		t.Fatalf("disputes not returned = %v", createdDisputeIDs)
+	}
+}
+
 func TestDisputeFinalize(t *testing.T) {
 	t.Parallel()
 

--- a/dispute_integration_test.go
+++ b/dispute_integration_test.go
@@ -110,8 +110,8 @@ func TestDisputeSearchPage(t *testing.T) {
 			t.Fatalf("failed to search dispute: %v; page %d", err, page)
 		}
 
-		if result.TotalPages != 2 {
-			t.Fatalf("expected 2 pages of disputes, but got %d", result.TotalPages)
+		if result.PageCount != 2 {
+			t.Fatalf("expected 2 pages of disputes, but got %d", result.PageCount)
 		}
 
 		if result.TotalItems != transactionCount {
@@ -123,7 +123,7 @@ func TestDisputeSearchPage(t *testing.T) {
 		}
 
 		page++
-		if (page > result.TotalPages) {
+		if (page > result.PageCount) {
 			break
 		}
 	}
@@ -192,8 +192,8 @@ func TestDisputeSearchNext(t *testing.T) {
 			break;
 		}
 
-		if result.TotalPages != 2 {
-			t.Fatalf("expected 2 pages of disputes, but got %d", result.TotalPages)
+		if result.PageCount != 2 {
+			t.Fatalf("expected 2 pages of disputes, but got %d", result.PageCount)
 		}
 
 		if result.TotalItems != transactionCount {

--- a/dispute_integration_test.go
+++ b/dispute_integration_test.go
@@ -63,7 +63,6 @@ func TestDisputeSearch(t *testing.T) {
 
 	err = dg.Finalize(ctx, dispute.ID)
 
-	// test
 	if err != nil {
 		t.Fatalf("failed to finalize dispute: %v", err)
 	}
@@ -77,7 +76,7 @@ func TestDisputeSearchPage(t *testing.T) {
 
 	customer, err := cg.Create(ctx, &CustomerRequest{
 		FirstName: "John",
-		LastName: "Smith",
+		LastName:  "Smith",
 	})
 
 	if err != nil {
@@ -88,8 +87,8 @@ func TestDisputeSearchPage(t *testing.T) {
 	createdDisputeIDs := map[string]bool{}
 	for i := 0; i < transactionCount; i++ {
 		tx, err := txg.Create(ctx, &TransactionRequest{
-			Type:   "sale",
-			Amount: NewDecimal(100, 2),
+			Type:       "sale",
+			Amount:     NewDecimal(100, 2),
 			CustomerID: customer.Id,
 			CreditCard: &CreditCard{
 				Number:         "4023898493988028",
@@ -162,7 +161,7 @@ func TestDisputeSearchNext(t *testing.T) {
 
 	customer, err := cg.Create(ctx, &CustomerRequest{
 		FirstName: "John",
-		LastName: "Smith",
+		LastName:  "Smith",
 	})
 
 	if err != nil {
@@ -173,8 +172,8 @@ func TestDisputeSearchNext(t *testing.T) {
 	createdDisputeIDs := map[string]bool{}
 	for i := 0; i < transactionCount; i++ {
 		tx, err := txg.Create(ctx, &TransactionRequest{
-			Type:   "sale",
-			Amount: NewDecimal(100, 2),
+			Type:       "sale",
+			Amount:     NewDecimal(100, 2),
 			CustomerID: customer.Id,
 			CreditCard: &CreditCard{
 				Number:         "4023898493988028",

--- a/dispute_integration_test.go
+++ b/dispute_integration_test.go
@@ -77,8 +77,8 @@ func TestDisputeSearchPage(t *testing.T) {
 	createdDisputeIDs := map[string]bool{}
 	for i := 0; i < transactionCount; i++ {
 		tx, err := txg.Create(ctx, &TransactionRequest{
-			Type: 			"sale",
-			Amount: 		NewDecimal(100, 2),
+			Type:   "sale",
+			Amount: NewDecimal(100, 2),
 			CreditCard: &CreditCard{
 				Number:         "4023898493988028",
 				ExpirationDate: "12/" + time.Now().Format("2006"),
@@ -123,7 +123,7 @@ func TestDisputeSearchPage(t *testing.T) {
 		}
 
 		page++
-		if (page > result.PageCount) {
+		if page > result.PageCount {
 			break
 		}
 	}
@@ -150,8 +150,8 @@ func TestDisputeSearchNext(t *testing.T) {
 	createdDisputeIDs := map[string]bool{}
 	for i := 0; i < transactionCount; i++ {
 		tx, err := txg.Create(ctx, &TransactionRequest{
-			Type: 			"sale",
-			Amount: 		NewDecimal(100, 2),
+			Type:   "sale",
+			Amount: NewDecimal(100, 2),
 			CreditCard: &CreditCard{
 				Number:         "4023898493988028",
 				ExpirationDate: "12/" + time.Now().Format("2006"),
@@ -178,7 +178,7 @@ func TestDisputeSearchNext(t *testing.T) {
 	var err error
 
 	for {
-		if (index == 0) {
+		if index == 0 {
 			result, err = dg.Search(ctx, query)
 		} else {
 			result, err = dg.SearchNext(ctx, query, result)
@@ -189,7 +189,7 @@ func TestDisputeSearchNext(t *testing.T) {
 		}
 
 		if result == nil && err == nil {
-			break;
+			break
 		}
 
 		if result.PageCount != 2 {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,1 @@
 module github.com/braintree-go/braintree-go
-
-go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/braintree-go/braintree-go
+
+go 1.12


### PR DESCRIPTION
This PR implements search functions (`Search`, `SearchNext` and `SearchPage`) for `Dispute` resource. 

Its behavior is somehow different than `Customer` / `Subscription` / `Transaction` paginated search has implemented as there isn't `/dispute/advanced_search_ids` endpoint (correct me if I'm wrong!) that could provide a list of matching resource ids.

Let me know if there is anything that could/should be improved.

Closes #239 