### PR TITLE
Fix test for go 1.13

### DIFF
--- a/init_test.go
+++ b/init_test.go
@@ -79,8 +79,8 @@ func testSubMerchantAccount() string {
 
 func init() {
 	logEnabled := flag.Bool("log", false, "enables logging")
-    testing.Init()
-    flag.Parse()
+	testing.Init()
+	flag.Parse()
 
 	if *logEnabled {
 		testGateway.Logger = log.New(os.Stderr, "", 0)

--- a/init_test.go
+++ b/init_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"testing"
 	"time"
 
 	"github.com/braintree-go/braintree-go/testhelpers"
@@ -78,7 +79,8 @@ func testSubMerchantAccount() string {
 
 func init() {
 	logEnabled := flag.Bool("log", false, "enables logging")
-	flag.Parse()
+    testing.Init()
+    flag.Parse()
 
 	if *logEnabled {
 		testGateway.Logger = log.New(os.Stderr, "", 0)


### PR DESCRIPTION
go 1.13 update how test initialize flags. For that reason calling `flag.Parse` in init function fails https://golang.org/doc/go1.13#testing
easiest workaround is to call `testing.Init()` before calling `flag.Parse` to flag is registered before parsing